### PR TITLE
update documentation to correct pycomm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ ROS2 Solution for FANUC robots
 
 ### Prerequisites
 
-* pycomm
+* pycomm3
   ```sh
-  pip3 install pycomm
+  pip3 install pycomm3
   ```
 * Put Fanuc TP programs on controller
     - 'ros2_eip_back.tp' needs to be running in the background


### PR DESCRIPTION
Documentation says to install pycomm, but pycomm3 is used in code. 
pip installing pycomm will throw an erorr when trying to run the ros2 node.