### PR TITLE
## PR #1: Critical Bug Fix for Python Bindings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,11 @@ ROS2 Solution for FANUC robots
 
 ### Prerequisites
 
-* pycomm3
+* ROS2 Jazzy (or Humble)
+* Python 3 and pip
+* catkin_pkg (required for ROS2 build system)
   ```sh
-  pip3 install pycomm3
+  sudo apt install python3-catkin-pkg python3-rosdep
   ```
 * Put Fanuc TP programs on controller
     - 'ros2_eip_back.tp' needs to be running in the background
@@ -79,9 +81,9 @@ ROS2 Solution for FANUC robots
 ### Installation (Linux)
 
 #### Create a ROS2 Workspace
-1. Source ROS2 Environment
+1. Source ROS2 Environment (use jazzy or humble depending on your installation)
    ```sh
-   source /opt/ros/humble/setup.bash
+   source /opt/ros/jazzy/setup.bash
    ```
 2. Create a new directory
    ```sh
@@ -92,11 +94,20 @@ ROS2 Solution for FANUC robots
    ```sh
    git clone https://github.com/UofI-CDACS/fanuc_ros2_drivers/ --branch v1.1
    ```
-4. Resolve Dependencies
+4. Initialize rosdep (first time only)
    ```sh
-   rosdep install -i --from-path src --rosdistro humble -y
+   sudo rosdep init
+   rosdep update
    ```
-5. Build the workspace with colcon
+5. Resolve Dependencies (use jazzy or humble to match your ROS2 version)
+   ```sh
+   rosdep install -i --from-path src --rosdistro jazzy -y
+   ```
+   Note: pycomm3 may need to be installed separately:
+   ```sh
+   pip3 install pycomm3
+   ```
+6. Build the workspace with colcon
    ```sh
    colcon build
    ```

--- a/src/fanuc_interfaces/package.xml
+++ b/src/fanuc_interfaces/package.xml
@@ -10,6 +10,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
**Single file change:**
1. **`src/fanuc_interfaces/package.xml`**
  ```xml <exec_depend>rosidl_default_runtime</exec_depend> ``` 

 Without this, ROS2 won't generate Python bindings for the custom interfaces on Ubuntu. The package will build but all nodes will fail with `ModuleNotFoundError: No module named 'fanuc_interfaces'`.

Another PR will be included soon to also update some of the readme.md instructions. i will have a full guide on my other repo 