### PR TITLE
cole final project

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+ROBOT_1_NAME=your_robot_name
+ROBOT_1_IP=0.0.0.0
+ROBOT_2_NAME=your_robot_name
+ROBOT_2_IP=0.0.0.0

--- a/justfile
+++ b/justfile
@@ -1,0 +1,120 @@
+set dotenv-load := true
+
+ros_setup  := "/opt/ros/jazzy/setup.bash"
+ws_setup   := "install/setup.bash"
+venv_pkgs  := justfile_directory() + "/.venv/lib/python3.12/site-packages"
+robot1     := env('ROBOT_1_NAME', 'robot1')
+robot1_ip  := env('ROBOT_1_IP', '0.0.0.0')
+robot2     := env('ROBOT_2_NAME', 'robot2')
+robot2_ip  := env('ROBOT_2_IP', '0.0.0.0')
+
+# One-time: create .venv, install Python deps, vendor mvsdk.py into the venv
+setup:
+    python3.12 -m venv .venv
+    .venv/bin/pip install --upgrade pip
+    .venv/bin/pip install -r requirements.txt
+    cp third_party/mvsdk.py {{venv_pkgs}}/
+
+# Print commands to source workspace + venv overlay in current shell
+source:
+    @echo "Run the following in your shell:"
+    @echo "  source /opt/ros/jazzy/setup.bash && source install/setup.bash"
+    @echo "  export PYTHONPATH={{venv_pkgs}}:\${PYTHONPATH:-}"
+
+# Build the workspace
+build:
+    bash -c "source {{ros_setup}} && PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} colcon build"
+
+# Launch both robot server stacks + camera node (Ctrl+C stops all)
+launch:
+    bash -c "source {{ros_setup}} && source {{ws_setup}} && \
+        PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} \
+        ros2 launch launch/start.launch.py robot_name:={{robot1}} robot_ip:={{robot1_ip}} & \
+        PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} \
+        ros2 launch launch/start.launch.py robot_name:={{robot2}} robot_ip:={{robot2_ip}} & \
+        PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} \
+        ros2 run dual_fanuc mv_camera_node & \
+        wait"
+
+# Launch Robot 1 server stack + camera node only
+launch1:
+    bash -c "source {{ros_setup}} && source {{ws_setup}} && \
+        PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} \
+        ros2 launch launch/start.launch.py robot_name:={{robot1}} robot_ip:={{robot1_ip}} & \
+        PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} \
+        ros2 run dual_fanuc mv_camera_node & \
+        wait"
+
+# Launch Robot 2 server stack only
+launch2:
+    bash -c "source {{ros_setup}} && source {{ws_setup}} && \
+        PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} \
+        ros2 launch launch/start.launch.py robot_name:={{robot2}} robot_ip:={{robot2_ip}} & \
+        wait"
+
+# Grab a single frame via ROS2 camera node (node must be running) → /tmp/grab.bmp
+grab:
+    bash -c "source {{ros_setup}} && source {{ws_setup}} && PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} python3 scripts/grab.py"
+
+# Grab a single frame directly via SDK (camera node must NOT be running) → /tmp/grab.bmp
+grab-sdk:
+    bash -c "PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} python3 scripts/grab_sdk.py"
+
+# Open Robot 1 Schunk gripper (launch1 must be running)
+open-schunk:
+    bash -c "source {{ros_setup}} && source {{ws_setup}} && PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} python3 scripts/test_gripper.py schunk open {{robot1}}"
+
+# Close Robot 1 Schunk gripper (launch1 must be running)
+close-schunk:
+    bash -c "source {{ros_setup}} && source {{ws_setup}} && PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} python3 scripts/test_gripper.py schunk close {{robot1}}"
+
+# Open Robot 2 OnRobot gripper (launch2 must be running)
+open-onrobot:
+    bash -c "source {{ros_setup}} && source {{ws_setup}} && PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} python3 scripts/test_gripper.py onrobot open {{robot2}}"
+
+# Close Robot 2 OnRobot gripper (launch2 must be running)
+close-onrobot:
+    bash -c "source {{ros_setup}} && source {{ws_setup}} && PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} python3 scripts/test_gripper.py onrobot close {{robot2}}"
+
+# Run Robot 1 — pick/present/analyse/place loop
+run:
+    bash -c "source {{ros_setup}} && source {{ws_setup}} && PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} ros2 run dual_fanuc robot1"
+
+# Run Robot 2 — waits for pip count from Robot 1, then acts
+run2:
+    bash -c "source {{ros_setup}} && source {{ws_setup}} && PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} ros2 run dual_fanuc robot2"
+
+# Robot 1: pick die from DICE_PICK, place at DICE_PLACE, run all five rotation primitives
+rotate1:
+    bash -c "source {{ros_setup}} && source {{ws_setup}} && PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} ros2 run dual_fanuc rotate1"
+
+# Robot 2: assume die is at DICE_PLACE, run all five rotation primitives
+rotate2:
+    bash -c "source {{ros_setup}} && source {{ws_setup}} && PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} ros2 run dual_fanuc rotate2"
+
+# Run front conveyor (Robot 2) forward until Ctrl+C
+conveyer-front:
+    bash -c "source {{ros_setup}} && source {{ws_setup}} && PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} python3 scripts/test_conveyor.py front {{robot2}}"
+
+# Run back conveyor (Robot 1) forward until Ctrl+C
+conveyer-back:
+    bash -c "source {{ros_setup}} && source {{ws_setup}} && PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} python3 scripts/test_conveyor.py back {{robot1}}"
+
+# Tune HSV crop parameters interactively (run 'just grab' first to get an image)
+calibrate-hsv:
+    bash -c "PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} python3 scripts/calibrate_hsv.py"
+
+# Tune HoughCircles parameters interactively (run 'just calibrate-hsv' first to get a cropped image)
+calibrate-hough:
+    bash -c "PYTHONPATH={{venv_pkgs}}:${PYTHONPATH:-} python3 scripts/calibrate_hough.py"
+
+# Force-kill all ROS2 nodes and related processes
+kill:
+    #!/usr/bin/env bash
+    pkill -9 -f "ros2"          || true
+    pkill -9 -f "robot_controller" || true
+    pkill -9 -f "action_servers"   || true
+    pkill -9 -f "msg_publishers"   || true
+    pkill -9 -f "srv_services"     || true
+    pkill -9 -f "dual_fanuc"       || true
+    echo "All ROS2 processes killed."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pycomm3
+pynput
+opencv-python
+numpy<2  # ROS Jazzy cv_bridge is compiled against numpy 1.x ABI; do not bump
+evdev

--- a/scripts/calibrate_hough.py
+++ b/scripts/calibrate_hough.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+calibrate_hough.py
+------------------
+Interactive HoughCircles tuner for pip detection across multiple dice.
+
+Usage:
+    python3 scripts/calibrate_hough.py
+
+Loads the pre-cropped die images saved by 'just calibrate-hsv'
+(/tmp/grab_cropped_0.bmp, _1.bmp, ...) so Hough runs on exactly the same
+crops you tuned in the HSV tool.
+
+Press 'q' or ESC to quit — final parameters are written back into robot1.py.
+"""
+import re
+import glob
+import cv2
+import numpy as np
+from pathlib import Path
+
+SRC_DIR = Path(__file__).parent.parent / 'src' / 'dual_fanuc' / 'dual_fanuc'
+ROBOT1  = SRC_DIR / 'robot1.py'
+ROBOT2  = SRC_DIR / 'robot2.py'
+
+# ── Load pre-cropped images from calibrate_hsv ────────────────────────────────
+crop_paths = sorted(glob.glob('/tmp/grab_cropped_*.bmp'))
+if not crop_paths:
+    # Fall back to legacy single-crop name
+    if Path('/tmp/grab_cropped.bmp').exists():
+        crop_paths = ['/tmp/grab_cropped.bmp']
+    else:
+        print("No cropped images found. Run 'just calibrate-hsv' first.")
+        raise SystemExit(1)
+
+crops = []
+for p in crop_paths:
+    img = cv2.imread(p)
+    if img is not None:
+        crops.append(img)
+        print(f"Loaded: {p}  ({img.shape[1]}×{img.shape[0]})")
+
+if not crops:
+    print("Could not read any crop files.")
+    raise SystemExit(1)
+
+print(f"{len(crops)} die crop(s) loaded.")
+
+# ── Read current Hough defaults from robot1.py ────────────────────────────────
+def _read_int(text, name, default):
+    m = re.search(rf'^{re.escape(name)}\s*=\s*(\d+)', text, re.MULTILINE)
+    return int(m.group(1)) if m else default
+
+def _read_float(text, name, default):
+    m = re.search(rf'^{re.escape(name)}\s*=\s*([\d.]+)', text, re.MULTILINE)
+    return float(m.group(1)) if m else default
+
+robot1_text   = ROBOT1.read_text()
+dp_init       = int(_read_float(robot1_text, 'HOUGH_DP',       1.2) * 10)
+minDist_init  = _read_int(robot1_text, 'HOUGH_MIN_DIST', 20)
+param1_init   = _read_int(robot1_text, 'HOUGH_PARAM1',   50)
+param2_init   = _read_int(robot1_text, 'HOUGH_PARAM2',   25)
+minR_init     = _read_int(robot1_text, 'HOUGH_MIN_R',    0)
+maxR_init     = _read_int(robot1_text, 'HOUGH_MAX_R',    20)
+
+# Pre-blur each crop once (blur doesn't depend on Hough params)
+blurred_crops = []
+for crop in crops:
+    gray    = cv2.cvtColor(crop, cv2.COLOR_BGR2GRAY)
+    blurred = cv2.GaussianBlur(gray, (11, 11), 2)
+    blurred_crops.append(blurred)
+
+WIN = 'HoughCircles Calibration  (q / ESC to quit)'
+cv2.namedWindow(WIN, cv2.WINDOW_NORMAL)
+cv2.resizeWindow(WIN, 1200, 700)
+
+cv2.createTrackbar('dp  x10',   WIN, dp_init,      30,  lambda _: None)
+cv2.createTrackbar('minDist',   WIN, minDist_init,  300, lambda _: None)
+cv2.createTrackbar('param1',    WIN, param1_init,   300, lambda _: None)
+cv2.createTrackbar('param2',    WIN, param2_init,   100, lambda _: None)
+cv2.createTrackbar('minRadius', WIN, minR_init,     150, lambda _: None)
+cv2.createTrackbar('maxRadius', WIN, maxR_init,     300, lambda _: None)
+
+PANEL_H   = 700
+SUMMARY_W = 400
+last_params = None
+
+
+def make_mosaic(annotated_crops, panel_h):
+    if not annotated_crops:
+        return np.zeros((panel_h, 400, 3), dtype=np.uint8)
+    n    = len(annotated_crops)
+    cols = int(np.ceil(np.sqrt(n)))
+    rows = int(np.ceil(n / cols))
+    max_h = max(c.shape[0] for c in annotated_crops)
+    max_w = max(c.shape[1] for c in annotated_crops)
+    scale = min((panel_h // rows) / max(max_h, 1), 600 / max(max_w, 1))
+    cw    = max(1, int(max_w * scale))
+    ch    = max(1, int(max_h * scale))
+    canvas = np.zeros((rows * ch, cols * cw, 3), dtype=np.uint8)
+    for i, crop in enumerate(annotated_crops):
+        r, c = divmod(i, cols)
+        resized = cv2.resize(crop, (cw, ch))
+        canvas[r*ch:(r+1)*ch, c*cw:(c+1)*cw] = resized
+    return canvas
+
+
+while True:
+    dp        = max(0.1, cv2.getTrackbarPos('dp  x10',   WIN) / 10.0)
+    minDist   = max(1,   cv2.getTrackbarPos('minDist',   WIN))
+    param1    = max(1,   cv2.getTrackbarPos('param1',    WIN))
+    param2    = max(1,   cv2.getTrackbarPos('param2',    WIN))
+    minRadius =          cv2.getTrackbarPos('minRadius', WIN)
+    maxRadius =          cv2.getTrackbarPos('maxRadius', WIN)
+
+    total_pips      = 0
+    annotated_crops = []
+    counts          = []
+
+    for crop, blurred in zip(crops, blurred_crops):
+        circles = cv2.HoughCircles(blurred, cv2.HOUGH_GRADIENT,
+                                   dp=dp, minDist=minDist,
+                                   param1=param1, param2=param2,
+                                   minRadius=minRadius, maxRadius=maxRadius)
+        display = crop.copy()
+        count = 0
+        if circles is not None:
+            count = len(circles[0])
+            for (cx, cy, r) in np.round(circles[0]).astype(int):
+                cv2.circle(display, (cx, cy), r, (0, 255, 0), 2)
+                cv2.circle(display, (cx, cy), 3, (0, 0, 255), -1)
+        colour = (0, 255, 0) if count > 0 else (0, 0, 255)
+        cv2.putText(display, f'Pips: {count}', (5, 25),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.8, colour, 2)
+        annotated_crops.append(display)
+        counts.append(count)
+        total_pips += count
+
+    mosaic = make_mosaic(annotated_crops, PANEL_H)
+    scale_m = PANEL_H / max(mosaic.shape[0], 1)
+    mosaic  = cv2.resize(mosaic, (int(mosaic.shape[1] * scale_m), PANEL_H))
+
+    summary = np.zeros((PANEL_H, SUMMARY_W, 3), dtype=np.uint8)
+    cv2.putText(summary, f'Dice: {len(crops)}', (20, 50),
+                cv2.FONT_HERSHEY_SIMPLEX, 1.0, (255, 255, 255), 2)
+    cv2.putText(summary, f'Total pips: {total_pips}', (20, 100),
+                cv2.FONT_HERSHEY_SIMPLEX, 1.0, (0, 255, 255), 2)
+    for i, cnt in enumerate(counts):
+        col = (0, 255, 0) if cnt > 0 else (0, 0, 255)
+        cv2.putText(summary, f'  Die #{i+1}: {cnt}', (20, 160 + i * 40),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.8, col, 2)
+    cv2.putText(summary, 'q/ESC to save+quit', (20, PANEL_H - 20),
+                cv2.FONT_HERSHEY_SIMPLEX, 0.6, (180, 180, 180), 1)
+
+    frame = np.hstack([summary, mosaic])
+    cv2.imshow(WIN, frame)
+
+    params = (dp, minDist, param1, param2, minRadius, maxRadius)
+    if params != last_params:
+        last_params = params
+        counts_str = '  '.join(f'#{i+1}:{c}' for i, c in enumerate(counts))
+        print(f"Total: {total_pips}  [{counts_str}]  |  "
+              f"dp={dp:.1f}  minDist={minDist}  param1={param1}  "
+              f"param2={param2}  minR={minRadius}  maxR={maxRadius}")
+
+    if cv2.waitKey(50) & 0xFF in (ord('q'), 27):
+        break
+
+cv2.destroyAllWindows()
+
+# ── Auto-update robot1.py ─────────────────────────────────────────────────────
+replacements = {
+    'HOUGH_DP':       f'{dp:.1f}',
+    'HOUGH_MIN_DIST': str(minDist),
+    'HOUGH_PARAM1':   str(param1),
+    'HOUGH_PARAM2':   str(param2),
+    'HOUGH_MIN_R':    str(minRadius),
+    'HOUGH_MAX_R':    str(maxRadius),
+}
+
+for path in (ROBOT1, ROBOT2):
+    text = path.read_text()
+    for name, value in replacements.items():
+        text = re.sub(
+            rf'^({re.escape(name)}\s*=\s*)[\d.]+',
+            lambda m, v=value: m.group(1) + v,
+            text,
+            flags=re.MULTILINE,
+        )
+    path.write_text(text)
+    print(f"\nUpdated {path}:")
+    for name, value in replacements.items():
+        print(f"  {name} = {value}")

--- a/scripts/calibrate_hsv.py
+++ b/scripts/calibrate_hsv.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""
+calibrate_hsv.py
+----------------
+Interactive ROI + HSV tuner for isolating yellow die faces before pip counting.
+
+Usage:
+    python3 scripts/calibrate_hsv.py [image_path]
+
+If no image path is given, loads /tmp/grab.bmp (from 'just grab').
+
+Sliders:
+  ROI X1 / Y1 / X2 / Y2 — outer crop applied before HSV detection
+  H/S/V low+high        — yellow-mask bounds
+  min area /100         — discard contours below this many pixels²
+
+Left panel  — original image with the ROI rectangle and per-die boxes.
+Right panel — mosaic of the cropped die regions (these are saved to
+              /tmp/grab_cropped_*.bmp for calibrate_hough).
+
+Press 'q' or ESC to quit — final values are written back into BOTH
+robot1.py and robot2.py.
+"""
+import sys
+import re
+import cv2
+import numpy as np
+from pathlib import Path
+
+IMAGE_PATH = sys.argv[1] if len(sys.argv) > 1 else '/tmp/grab.bmp'
+SRC_DIR    = Path(__file__).parent.parent / 'src' / 'dual_fanuc' / 'dual_fanuc'
+ROBOT1     = SRC_DIR / 'robot1.py'
+ROBOT2     = SRC_DIR / 'robot2.py'
+
+img = cv2.imread(IMAGE_PATH)
+if img is None:
+    print(f'Could not load image: {IMAGE_PATH}')
+    print("Run 'just grab' first to capture a calibration image.")
+    raise SystemExit(1)
+
+H, W = img.shape[:2]
+
+
+# ── Read current values from robot1.py so sliders persist between runs ────────
+def _read_int(text, name, default):
+    m = re.search(rf'^{re.escape(name)}\s*=\s*(\d+)', text, re.MULTILINE)
+    return int(m.group(1)) if m else default
+
+
+robot1_text     = ROBOT1.read_text()
+H_LOW_INIT      = _read_int(robot1_text, 'HSV_H_LOW',  20)
+S_LOW_INIT      = _read_int(robot1_text, 'HSV_S_LOW',  100)
+V_LOW_INIT      = _read_int(robot1_text, 'HSV_V_LOW',  100)
+H_HIGH_INIT     = _read_int(robot1_text, 'HSV_H_HIGH', 35)
+S_HIGH_INIT     = _read_int(robot1_text, 'HSV_S_HIGH', 255)
+V_HIGH_INIT     = _read_int(robot1_text, 'HSV_V_HIGH', 255)
+MIN_AREA_INIT   = _read_int(robot1_text, 'MIN_CONTOUR_AREA', 2000) // 100
+ROI_X1_INIT     = _read_int(robot1_text, 'ROI_X1', 0)
+ROI_Y1_INIT     = _read_int(robot1_text, 'ROI_Y1', 0)
+ROI_X2_INIT     = _read_int(robot1_text, 'ROI_X2', W)
+ROI_Y2_INIT     = _read_int(robot1_text, 'ROI_Y2', H)
+
+# Clamp ROI defaults to image bounds in case the constants outpace this image.
+ROI_X1_INIT = min(max(ROI_X1_INIT, 0), W - 1)
+ROI_Y1_INIT = min(max(ROI_Y1_INIT, 0), H - 1)
+ROI_X2_INIT = min(max(ROI_X2_INIT, 1), W)
+ROI_Y2_INIT = min(max(ROI_Y2_INIT, 1), H)
+
+WIN = 'HSV + ROI Crop Calibration  (q / ESC to quit)'
+cv2.namedWindow(WIN, cv2.WINDOW_NORMAL)
+cv2.resizeWindow(WIN, 1600, 900)
+
+# Short trackbar names ↔ readable in-frame labels (defined below).
+_TRACKBARS = [
+    ('roi_x1', 'ROI x1',  ROI_X1_INIT,   max(W - 1, 1)),
+    ('roi_y1', 'ROI y1',  ROI_Y1_INIT,   max(H - 1, 1)),
+    ('roi_x2', 'ROI x2',  ROI_X2_INIT,   W),
+    ('roi_y2', 'ROI y2',  ROI_Y2_INIT,   H),
+    ('h_lo',   'H low',   H_LOW_INIT,    179),
+    ('s_lo',   'S low',   S_LOW_INIT,    255),
+    ('v_lo',   'V low',   V_LOW_INIT,    255),
+    ('h_hi',   'H high',  H_HIGH_INIT,   179),
+    ('s_hi',   'S high',  S_HIGH_INIT,   255),
+    ('v_hi',   'V high',  V_HIGH_INIT,   255),
+    ('area',   'min area /100', MIN_AREA_INIT, 500),
+]
+for short, _label, init, vmax in _TRACKBARS:
+    cv2.createTrackbar(short, WIN, init, vmax, lambda _: None)
+
+
+def _draw_readout(canvas, values, count, ok):
+    """Render a sidebar showing all parameter values with full labels."""
+    panel_w  = 240
+    h        = canvas.shape[0]
+    sidebar  = np.full((h, panel_w, 3), 30, dtype=np.uint8)
+    line_h   = 28
+    y        = 30
+
+    sections = [
+        ('ROI',       [(0, 'roi_x1'), (1, 'roi_y1'), (2, 'roi_x2'), (3, 'roi_y2')], (90, 200, 255)),
+        ('HSV low',   [(4, 'h_lo'),   (5, 's_lo'),   (6, 'v_lo')],                  (255, 200, 90)),
+        ('HSV high',  [(7, 'h_hi'),   (8, 's_hi'),   (9, 'v_hi')],                  (160, 255, 160)),
+        ('Filter',    [(10, 'area')],                                              (220, 220, 220)),
+    ]
+
+    label_lookup = {short: full for short, full, _, _ in _TRACKBARS}
+    for title, rows, colour in sections:
+        cv2.putText(sidebar, title, (12, y), cv2.FONT_HERSHEY_SIMPLEX, 0.6, colour, 1, cv2.LINE_AA)
+        y += line_h
+        for idx, short in rows:
+            label = label_lookup[short]
+            val   = values[idx]
+            cv2.putText(sidebar, f'  {label:<14} {val}',
+                        (12, y), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (240, 240, 240), 1, cv2.LINE_AA)
+            y += line_h
+        y += 8
+
+    # Found-die count.
+    y += 10
+    col = (90, 255, 90) if ok else (90, 90, 255)
+    cv2.putText(sidebar, f'{count} die(s) found', (12, y),
+                cv2.FONT_HERSHEY_SIMPLEX, 0.7, col, 2, cv2.LINE_AA)
+    cv2.putText(sidebar, "q / ESC to save+quit", (12, h - 16),
+                cv2.FONT_HERSHEY_SIMPLEX, 0.5, (160, 160, 160), 1, cv2.LINE_AA)
+    return sidebar
+
+
+kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (5, 5))
+PAD = 10
+last_params = None
+
+PANEL_W = img.shape[1] // 2
+PANEL_H = img.shape[0]
+
+
+def make_mosaic(crops, panel_w, panel_h):
+    """Tile crops into a panel. Returns a blank panel if no crops."""
+    if not crops:
+        blank = np.zeros((panel_h, panel_w, 3), dtype=np.uint8)
+        cv2.putText(blank, 'No dice found', (20, panel_h // 2),
+                    cv2.FONT_HERSHEY_SIMPLEX, 1.0, (0, 0, 255), 2)
+        return blank
+
+    n = len(crops)
+    cols = int(np.ceil(np.sqrt(n)))
+    rows = int(np.ceil(n / cols))
+    cell_w = panel_w // cols
+    cell_h = panel_h // rows
+
+    canvas = np.zeros((panel_h, panel_w, 3), dtype=np.uint8)
+    for i, crop in enumerate(crops):
+        r, c = divmod(i, cols)
+        scale = min(cell_w / max(crop.shape[1], 1), cell_h / max(crop.shape[0], 1))
+        cw = int(crop.shape[1] * scale)
+        ch = int(crop.shape[0] * scale)
+        resized = cv2.resize(crop, (cw, ch))
+        ox = c * cell_w + (cell_w - cw) // 2
+        oy = r * cell_h + (cell_h - ch) // 2
+        canvas[oy:oy+ch, ox:ox+cw] = resized
+        cv2.putText(canvas, f'#{i+1}', (c * cell_w + 5, r * cell_h + 20),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.6, (200, 200, 200), 1)
+    return canvas
+
+
+while True:
+    roi_x1   = cv2.getTrackbarPos('roi_x1', WIN)
+    roi_y1   = cv2.getTrackbarPos('roi_y1', WIN)
+    roi_x2   = cv2.getTrackbarPos('roi_x2', WIN)
+    roi_y2   = cv2.getTrackbarPos('roi_y2', WIN)
+    h_low    = cv2.getTrackbarPos('h_lo',   WIN)
+    s_low    = cv2.getTrackbarPos('s_lo',   WIN)
+    v_low    = cv2.getTrackbarPos('v_lo',   WIN)
+    h_high   = cv2.getTrackbarPos('h_hi',   WIN)
+    s_high   = cv2.getTrackbarPos('s_hi',   WIN)
+    v_high   = cv2.getTrackbarPos('v_hi',   WIN)
+    min_area = cv2.getTrackbarPos('area',   WIN) * 100
+
+    # Sanitise ROI so x2>x1 and y2>y1.
+    if roi_x2 <= roi_x1: roi_x2 = roi_x1 + 1
+    if roi_y2 <= roi_y1: roi_y2 = roi_y1 + 1
+
+    roi = img[roi_y1:roi_y2, roi_x1:roi_x2]
+    hsv  = cv2.cvtColor(roi, cv2.COLOR_BGR2HSV)
+    mask = cv2.inRange(hsv,
+                       np.array([h_low,  s_low,  v_low]),
+                       np.array([h_high, s_high, v_high]))
+    mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel)
+    mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN,  kernel)
+
+    all_contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    contours = [c for c in all_contours if cv2.contourArea(c) >= min_area]
+
+    annotated = img.copy()
+    cv2.rectangle(annotated, (roi_x1, roi_y1), (roi_x2, roi_y2), (0, 255, 255), 2)
+    crops = []
+
+    for i, c in enumerate(contours):
+        # Bounding rect is in ROI coords; shift back to full-image coords for the overlay.
+        x, y, w, h = cv2.boundingRect(c)
+        x1 = max(0, x - PAD);                  y1 = max(0, y - PAD)
+        x2 = min(roi.shape[1], x + w + PAD);   y2 = min(roi.shape[0], y + h + PAD)
+        gx1, gy1 = roi_x1 + x1, roi_y1 + y1
+        gx2, gy2 = roi_x1 + x2, roi_y1 + y2
+
+        cv2.rectangle(annotated, (gx1, gy1), (gx2, gy2), (0, 255, 0), 3)
+        cv2.putText(annotated, f'#{i+1}', (gx1, max(gy1 - 8, 18)),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 0), 2)
+
+        # Per-die fill mask so the saved crop is the die only — everything outside
+        # this contour goes to black. Pips remain visible (they're inside the
+        # contour's bounding box but originally black, so bitwise_and keeps them).
+        die_mask = np.zeros(roi.shape[:2], dtype=np.uint8)
+        cv2.drawContours(die_mask, [c], -1, 255, thickness=cv2.FILLED)
+        masked = cv2.bitwise_and(roi, roi, mask=die_mask)
+        crops.append(masked[y1:y2, x1:x2])
+
+    count_str = f'{len(contours)} die(s) found'
+    colour = (0, 255, 0) if contours else (0, 0, 255)
+    cv2.putText(annotated, count_str, (20, img.shape[0] - 20),
+                cv2.FONT_HERSHEY_SIMPLEX, 1.0, colour, 2)
+
+    left    = cv2.resize(annotated, (PANEL_W, PANEL_H))
+    right   = make_mosaic(crops, PANEL_W, PANEL_H)
+    sidebar = _draw_readout(
+        np.zeros((PANEL_H, 1, 3), dtype=np.uint8),  # height ref only
+        [roi_x1, roi_y1, roi_x2, roi_y2,
+         h_low, s_low, v_low, h_high, s_high, v_high, min_area // 100],
+        len(contours),
+        bool(contours),
+    )
+    frame = np.hstack([sidebar, left, right])
+    cv2.imshow(WIN, frame)
+
+    params = (roi_x1, roi_y1, roi_x2, roi_y2,
+              h_low, s_low, v_low, h_high, s_high, v_high, min_area)
+    if params != last_params:
+        last_params = params
+        print(f'Found: {len(contours)}  |  '
+              f'ROI [{roi_x1},{roi_y1}]–[{roi_x2},{roi_y2}]  |  '
+              f'H [{h_low}-{h_high}]  S [{s_low}-{s_high}]  V [{v_low}-{v_high}]  '
+              f'min_area={min_area}')
+
+    if cv2.waitKey(50) & 0xFF in (ord('q'), 27):
+        break
+
+cv2.destroyAllWindows()
+
+# ── Save crops for calibrate_hough.py ────────────────────────────────────────
+import glob as _glob, os as _os
+for _old in _glob.glob('/tmp/grab_cropped_*.bmp') + ['/tmp/grab_cropped.bmp']:
+    try: _os.remove(_old)
+    except FileNotFoundError: pass
+
+saved = 0
+if contours:
+    for i, c in enumerate(contours):
+        x, y, w, h = cv2.boundingRect(c)
+        x1 = max(0, x - PAD);                  y1 = max(0, y - PAD)
+        x2 = min(roi.shape[1], x + w + PAD);   y2 = min(roi.shape[0], y + h + PAD)
+        die_mask = np.zeros(roi.shape[:2], dtype=np.uint8)
+        cv2.drawContours(die_mask, [c], -1, 255, thickness=cv2.FILLED)
+        masked = cv2.bitwise_and(roi, roi, mask=die_mask)
+        cv2.imwrite(f'/tmp/grab_cropped_{i}.bmp', masked[y1:y2, x1:x2])
+        saved += 1
+    # Legacy single-file copy (also masked)
+    x, y, w, h = cv2.boundingRect(contours[0])
+    die_mask0 = np.zeros(roi.shape[:2], dtype=np.uint8)
+    cv2.drawContours(die_mask0, [contours[0]], -1, 255, thickness=cv2.FILLED)
+    masked0 = cv2.bitwise_and(roi, roi, mask=die_mask0)
+    cv2.imwrite('/tmp/grab_cropped.bmp', masked0[
+        max(0, y - PAD):min(roi.shape[0], y + h + PAD),
+        max(0, x - PAD):min(roi.shape[1], x + w + PAD),
+    ])
+    print(f'\nSaved {saved} crop(s) to /tmp/grab_cropped_0.bmp … /tmp/grab_cropped_{saved-1}.bmp')
+else:
+    print('\nWARN: no dice found — no crops saved.')
+
+# ── Auto-update both robot files ──────────────────────────────────────────────
+replacements = {
+    'HSV_H_LOW':        str(h_low),
+    'HSV_S_LOW':        str(s_low),
+    'HSV_V_LOW':        str(v_low),
+    'HSV_H_HIGH':       str(h_high),
+    'HSV_S_HIGH':       str(s_high),
+    'HSV_V_HIGH':       str(v_high),
+    'MIN_CONTOUR_AREA': str(min_area),
+    'ROI_X1':           str(roi_x1),
+    'ROI_Y1':           str(roi_y1),
+    'ROI_X2':           str(roi_x2),
+    'ROI_Y2':           str(roi_y2),
+}
+
+for path in (ROBOT1, ROBOT2):
+    text = path.read_text()
+    for name, value in replacements.items():
+        text = re.sub(
+            rf'^({re.escape(name)}\s*=\s*)\d+',
+            lambda m, v=value: m.group(1) + v,
+            text,
+            flags=re.MULTILINE,
+        )
+    path.write_text(text)
+    print(f'\nUpdated {path}:')
+    for name, value in replacements.items():
+        print(f'  {name} = {value}')

--- a/scripts/grab.py
+++ b/scripts/grab.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+grab.py
+-------
+Calls /mv_camera/capture then reads one frame from /mv_camera/image_raw
+and saves it to /tmp/grab.bmp.
+
+Requires the camera node (mv_camera_node) to already be running.
+Run with: just grab
+"""
+
+import sys
+import subprocess
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import Image
+from std_srvs.srv import Trigger
+from cv_bridge import CvBridge
+import cv2
+
+SAVE_PATH = '/tmp/grab.bmp'
+
+
+class GrabNode(Node):
+    def __init__(self):
+        super().__init__('grab_node')
+        self.bridge = CvBridge()
+        self.image  = None
+        self.sub    = self.create_subscription(Image, '/mv_camera/image_raw', self._cb, 10)
+        self.client = self.create_client(Trigger, '/mv_camera/capture')
+
+    def _cb(self, msg):
+        self.image = self.bridge.imgmsg_to_cv2(msg, desired_encoding='bgr8')
+
+    def grab(self):
+        if not self.client.wait_for_service(timeout_sec=3.0):
+            self.get_logger().error(
+                'Camera capture service not available — is mv_camera_node running?'
+            )
+            return False
+
+        # Trigger a fresh frame
+        future = self.client.call_async(Trigger.Request())
+        rclpy.spin_until_future_complete(self, future)
+        if not future.result().success:
+            self.get_logger().error('Camera capture service returned failure.')
+            return False
+
+        # Wait for the frame to arrive on the topic
+        deadline_ns = self.get_clock().now().nanoseconds + int(3.0 * 1e9)
+        while self.image is None:
+            rclpy.spin_once(self, timeout_sec=0.05)
+            if self.get_clock().now().nanoseconds > deadline_ns:
+                self.get_logger().error('Timed out waiting for image.')
+                return False
+
+        cv2.imwrite(SAVE_PATH, self.image)
+        self.get_logger().info(f'Image saved to {SAVE_PATH}')
+        subprocess.Popen(['xdg-open', SAVE_PATH])
+        return True
+
+
+def main():
+    rclpy.init()
+    node = GrabNode()
+    ok = node.grab()
+    node.destroy_node()
+    rclpy.shutdown()
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/grab_sdk.py
+++ b/scripts/grab_sdk.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+grab_sdk.py
+-----------
+Grabs a single frame directly from the MindVision camera using the SDK
+(no ROS2 required) and saves it to /tmp/grab.bmp.
+
+NOTE: The camera can only be opened by one process at a time.
+      Stop mv_camera_node before running this (i.e. don't use during just launch).
+
+Run with: just grab-sdk
+"""
+
+import sys
+import subprocess
+import numpy as np
+import cv2
+import mvsdk
+
+SAVE_PATH = '/tmp/grab.bmp'
+
+
+def _pick_routable_device(dev_list):
+    """When the host has multiple NICs, the SDK enumerates the camera once per route.
+    PortType is '<camera_ip>-<host_ip>'. Prefer the entry whose host_ip shares a /16
+    with the camera_ip (i.e. the path that actually carries data). Fall back to [0]."""
+    for d in dev_list:
+        port = d.GetPortType()
+        if '-' not in port:
+            continue
+        cam_ip, host_ip = port.split('-', 1)
+        cam_oct  = cam_ip.split('.')
+        host_oct = host_ip.split('.')
+        if len(cam_oct) >= 2 and len(host_oct) >= 2 and cam_oct[:2] == host_oct[:2]:
+            return d
+    return dev_list[0]
+
+
+def main():
+    dev_list = mvsdk.CameraEnumerateDevice()
+    if len(dev_list) < 1:
+        print('ERROR: No camera found. Check GigE connection and adapter IP.')
+        sys.exit(1)
+
+    dev_info = _pick_routable_device(dev_list)
+    print(f'Opening camera: {dev_info.GetFriendlyName()} via {dev_info.GetPortType()}')
+
+    try:
+        hCamera = mvsdk.CameraInit(dev_info, -1, -1)
+    except mvsdk.CameraException as e:
+        print(f'ERROR: CameraInit failed ({e.error_code}): {e.message}')
+        sys.exit(1)
+
+    try:
+        cap = mvsdk.CameraGetCapability(hCamera)
+        mono = cap.sIspCapacity.bMonoSensor != 0
+
+        if mono:
+            mvsdk.CameraSetIspOutFormat(hCamera, mvsdk.CAMERA_MEDIA_TYPE_MONO8)
+        else:
+            mvsdk.CameraSetIspOutFormat(hCamera, mvsdk.CAMERA_MEDIA_TYPE_BGR8)
+
+        mvsdk.CameraSetTriggerMode(hCamera, 0)       # continuous
+        mvsdk.CameraSetAeState(hCamera, 0)            # manual exposure
+        mvsdk.CameraSetExposureTime(hCamera, 30 * 1000)  # 30 ms
+
+        mvsdk.CameraPlay(hCamera)
+
+        buf_size = cap.sResolutionRange.iWidthMax * cap.sResolutionRange.iHeightMax * (1 if mono else 3)
+        pFrameBuffer = mvsdk.CameraAlignMalloc(buf_size, 16)
+
+        try:
+            pRawData, FrameHead = mvsdk.CameraGetImageBuffer(hCamera, 2000)
+            mvsdk.CameraImageProcess(hCamera, pRawData, pFrameBuffer, FrameHead)
+            mvsdk.CameraReleaseImageBuffer(hCamera, pRawData)
+
+            frame_data = (mvsdk.c_ubyte * FrameHead.uBytes).from_address(pFrameBuffer)
+            frame = np.frombuffer(frame_data, dtype=np.uint8)
+
+            if mono:
+                frame = frame.reshape((FrameHead.iHeight, FrameHead.iWidth))
+                frame = cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR)
+            else:
+                frame = frame.reshape((FrameHead.iHeight, FrameHead.iWidth, 3))
+
+            cv2.imwrite(SAVE_PATH, frame)
+            print(f'Saved: {SAVE_PATH}')
+            subprocess.Popen(['xdg-open', SAVE_PATH])
+
+        except mvsdk.CameraException as e:
+            print(f'ERROR: CameraGetImageBuffer failed ({e.error_code}): {e.message}')
+            sys.exit(1)
+
+        finally:
+            mvsdk.CameraAlignFree(pFrameBuffer)
+
+    finally:
+        mvsdk.CameraStop(hCamera)
+        mvsdk.CameraUnInit(hCamera)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/test_conveyor.py
+++ b/scripts/test_conveyor.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+test_conveyor.py
+----------------
+Conveyor belt test.
+
+  just conveyer         — forward → stop → reverse → stop
+  just conveyer-front   — forward only (runs until Ctrl+C, then stops)
+  just conveyer-back    — reverse only (runs until Ctrl+C, then stops)
+"""
+import os
+import sys
+import rclpy
+from rclpy.node import Node
+from rclpy.action import ActionClient
+from fanuc_interfaces.action import Conveyor
+
+PAUSE_SEC  = 2.0   # how long to run in each direction (full test only)
+MODE       = sys.argv[1] if len(sys.argv) > 1 else 'test'  # 'front' | 'back' | 'test'
+# Conveyor namespace: pass robot name as second arg, or fall back to env vars
+if len(sys.argv) > 2:
+    ROBOT_NAME = sys.argv[2]
+elif MODE == 'back':
+    ROBOT_NAME = os.environ.get('ROBOT_1_NAME', 'robot1')
+else:
+    ROBOT_NAME = os.environ.get('ROBOT_2_NAME', 'robot2')
+
+
+class ConveyorTestNode(Node):
+
+    def __init__(self):
+        super().__init__('conveyor_test')
+        self.ac = ActionClient(self, Conveyor, f'/{ROBOT_NAME}/conveyor')
+        self.get_logger().info(f'Waiting for /{ROBOT_NAME}/conveyor action server...')
+        self.ac.wait_for_server()
+        self.get_logger().info('Ready.')
+
+    def _send(self, command):
+        goal = Conveyor.Goal()
+        goal.command = command
+        self.get_logger().info(f'Sending: {command}')
+        future = self.ac.send_goal_async(goal)
+        rclpy.spin_until_future_complete(self, future)
+        gh = future.result()
+        if not gh.accepted:
+            self.get_logger().error(f'Goal "{command}" rejected.')
+            return
+        rf = gh.get_result_async()
+        rclpy.spin_until_future_complete(self, rf)
+        self.get_logger().info(f'"{command}" done — success={rf.result().result.success}')
+
+    def _pause(self, sec=PAUSE_SEC):
+        import time
+        time.sleep(sec)
+
+    def run(self):
+        if MODE == 'front':
+            self._send('forward')
+            self.get_logger().info('Running forward — press Ctrl+C to stop.')
+            try:
+                rclpy.spin(self)
+            except KeyboardInterrupt:
+                pass
+            self._send('stop')
+        elif MODE == 'back':
+            self._send('reverse')
+            self.get_logger().info('Running reverse — press Ctrl+C to stop.')
+            try:
+                rclpy.spin(self)
+            except KeyboardInterrupt:
+                pass
+            self._send('stop')
+        else:
+            self._send('forward');  self._pause()
+            self._send('stop');     self._pause(0.5)
+            self._send('reverse');  self._pause()
+            self._send('stop')
+            self.get_logger().info('Conveyor test complete.')
+
+
+def main():
+    rclpy.init()
+    node = ConveyorTestNode()
+    node.run()
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/test_gripper.py
+++ b/scripts/test_gripper.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+test_gripper.py
+---------------
+Test Schunk or OnRobot gripper commands.
+
+Usage (via just):
+    just open-schunk        — open Robot 1 Schunk gripper
+    just close-schunk       — close Robot 1 Schunk gripper
+    just open-onrobot       — open Robot 2 OnRobot gripper
+    just close-onrobot      — close Robot 2 OnRobot gripper
+
+Args: <gripper> <command> <robot_name>
+  gripper  : schunk | onrobot
+  command  : open | close
+  robot_name: robot name (from env)
+"""
+import sys
+import os
+import rclpy
+from rclpy.node import Node
+from rclpy.action import ActionClient
+from fanuc_interfaces.action import SchunkGripper, OnRobotGripper
+
+if len(sys.argv) < 4:
+    print('Usage: test_gripper.py <schunk|onrobot> <open|close> <robot_name>')
+    sys.exit(1)
+
+GRIPPER     = sys.argv[1]   # 'schunk' or 'onrobot'
+COMMAND     = sys.argv[2]   # 'open' or 'close'
+ROBOT_NAME  = sys.argv[3]
+
+# OnRobot open/close widths (mm) and force (N)
+ONROBOT_OPEN_WIDTH  = 100
+ONROBOT_CLOSE_WIDTH = 5
+ONROBOT_FORCE       = 40
+
+
+class GripperTestNode(Node):
+
+    def __init__(self):
+        super().__init__('gripper_test')
+
+        if GRIPPER == 'schunk':
+            topic = f'/{ROBOT_NAME}/schunk_gripper'
+            self.ac = ActionClient(self, SchunkGripper, topic)
+            self.get_logger().info(f'Waiting for {topic}...')
+            self.ac.wait_for_server()
+        elif GRIPPER == 'onrobot':
+            topic = f'/{ROBOT_NAME}/onrobot_gripper'
+            self.ac = ActionClient(self, OnRobotGripper, topic)
+            self.get_logger().info(f'Waiting for {topic}...')
+            self.ac.wait_for_server()
+        else:
+            self.get_logger().error(f'Unknown gripper: {GRIPPER}')
+            raise SystemExit(1)
+
+        self.get_logger().info('Ready.')
+
+    def run(self):
+        if GRIPPER == 'schunk':
+            goal = SchunkGripper.Goal()
+            goal.command = COMMAND
+        else:
+            goal = OnRobotGripper.Goal()
+            goal.width = ONROBOT_OPEN_WIDTH if COMMAND == 'open' else ONROBOT_CLOSE_WIDTH
+            goal.force = ONROBOT_FORCE
+
+        self.get_logger().info(f'{GRIPPER} {COMMAND}...')
+        future = self.ac.send_goal_async(goal)
+        rclpy.spin_until_future_complete(self, future)
+        gh = future.result()
+        if not gh.accepted:
+            self.get_logger().error('Goal rejected.')
+            return
+        rf = gh.get_result_async()
+        rclpy.spin_until_future_complete(self, rf)
+        self.get_logger().info(f'Done — success={rf.result().result.success}')
+
+
+def main():
+    rclpy.init()
+    node = GripperTestNode()
+    node.run()
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/dual_fanuc/README.md
+++ b/src/dual_fanuc/README.md
@@ -1,0 +1,126 @@
+<a name="readme-top"></a>
+
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+
+# ClaudeDualFanucAssignment
+
+A two-robot FANUC dice-orientation pipeline. Robot 1 (Schunk gripper) picks a die from a bin, scans it with an overhead MindVision GigE camera, flips it so a target pip lands on top, and hands it to Robot 2 (OnRobot gripper) over a back-and-forth conveyor pair. The two robots iterate through pips 1–6 and end the run with the final die placed at a fixed termination pose.
+
+This is a fork of an upstream FANUC ROS2 EtherNet/IP driver (`v1.1`). The upstream driver, action servers, message publishers, and TP programs are kept; everything above the driver is new.
+
+<details>
+<summary>Table of contents</summary>
+
+- [What this fork adds](#what-this-fork-adds)
+- [Prerequisites](#prerequisites)
+- [Setup](#setup)
+- [Running it](#running-it)
+- [Calibration](#calibration)
+- [License](#license)
+
+</details>
+
+
+## What this fork adds
+
+| Addition | Where | Purpose |
+|---|---|---|
+| `dual_fanuc` ROS2 package | `src/dual_fanuc/` | Two-robot orchestration: `robot1.py` (pick + present + sort) and `robot2.py` (receive + reorient + return). Shared lookup table in `pip_lookup.py` maps `(top, adjacent)` scan pairs to the single rotation primitive that brings each target pip to the top. |
+| MindVision camera node | `src/dual_fanuc/dual_fanuc/mv_camera_node.py` | Wraps the vendor `mvsdk` Python bindings as a ROS2 node. Publishes `/mv_camera/image_raw` and exposes a `/mv_camera/capture` trigger service for synchronous frames. Auto-selects the routable host NIC when multiple host IPs reach the camera. |
+| HSV + HoughCircles pip detector | `_crop_die` / `_count_pips` in `robot1.py` and `robot2.py` | Crops the die out of the scene by ROI → HSV mask → contour fill → bitwise-and, then counts pips on the masked crop. Tunable from `scripts/calibrate_hsv.py` and `scripts/calibrate_hough.py` (both write to both robot files). |
+| OnRobot gripper action server | `src/action_servers/action_servers/onrobot_server.py` | Width + force action interface for the OnRobot gripper on Robot 2. Robot 1 keeps the upstream Schunk action server. |
+| Rotation primitives + lookup-driven orient | `_rotate_x_pos_90`, `_rotate_x_neg_90`, `_rotate_y_neg_90`, `_rotate_y_pos_90`, `_flip_x_180`, `_orient_pip` / `_scan_orient_place` | Per-robot pure-motion primitives composed from a single x-flip primitive. Robot 1's single primitive is `_rotate_x_pos_90`, Robot 2's is `_rotate_x_neg_90` (the robots are mounted in mirrored orientations). The `pip_lookup` action labels are interpreted in each robot's local frame. |
+| `just` task runner | `justfile` | One-line recipes for every common workflow. `just --list` for the full set. |
+| Local-only env file | `.env` (gitignored) + `.env.example` | Robot names and IPs are read from `.env`; nothing real ships in the repo. |
+| Vendored Python SDK | `third_party/mvsdk.py`, copied into the venv by `just setup` | Avoids touching system site-packages. |
+| Rotation testers | `just rotate1`, `just rotate2` | Drive each robot through all five rotation primitives in isolation; useful when the camera or other robot is unavailable. |
+
+The upstream pieces — `fanuc_interfaces`, `msg_publishers`, `srv_services`, the cartesian/joint/Schunk/conveyor action servers, and the `FANUC_TP_Program/*.tp` files — are left as they were.
+
+
+## Prerequisites
+
+- **Linux** (developed on Ubuntu 24.04 with kernel 6.x).
+- **ROS2 Jazzy.** Humble may also work but is untested in this fork.
+- **Python 3.12** with `python3.12-venv`.
+- **`just`** ([install](https://github.com/casey/just?tab=readme-ov-file#installation)).
+- **MindVision Linux SDK** for the GigE camera. The vendor archive is included as `linuxSDK_V2.1.0.49(202602041120)/` locally but is gitignored — download it yourself from MindVision and run `sudo ./install.sh` from the extracted folder. This installs `/usr/lib/libMVSDK.so` and udev rules.
+- **Camera networking.** The MindVision camera ships in DHCP mode and falls back to a `169.254.x.x` link-local address with no DHCP server. Add a `169.254.0.1/16` IPv4 alias on the NIC the camera is plugged into so the host can route to the camera regardless of subnet (this is the typical fix when `just grab-sdk` returns MindVision error `-14`).
+- **FANUC TP programs.** Load both files from `FANUC_TP_Program/` onto each controller:
+  - `ros2_eip_back.tp` — must be running in the **background** on each controller.
+  - `ros2_eip_mainv2.tp` — runs in the **foreground** while you're using ROS.
+- **`numpy<2`.** ROS Jazzy's `cv_bridge` is compiled against the NumPy 1.x ABI. The pin is in `requirements.txt`; do not bump it without rebuilding `cv_bridge`.
+
+
+## Setup
+
+```sh
+# 1. Clone and configure environment
+git clone <your-fork-url> dual_fanuc_ws
+cd dual_fanuc_ws
+cp .env.example .env       # then edit ROBOT_1_NAME/IP and ROBOT_2_NAME/IP
+
+# 2. One-time tooling
+sudo apt install python3.12-venv python3-rosdep
+sudo rosdep init && rosdep update          # first time on this machine only
+rosdep install -i --from-path src --rosdistro jazzy -y
+
+# 3. Install MindVision SDK (download archive from vendor first)
+cd linuxSDK_V*/ && sudo ./install.sh && cd ..
+
+# 4. Python venv + workspace build
+just setup                  # creates .venv, installs requirements.txt, vendors mvsdk.py
+source /opt/ros/jazzy/setup.bash
+just build                  # colcon build
+```
+
+Every new shell after that needs the workspace overlay sourced before running ROS commands:
+
+```sh
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+export PYTHONPATH=$PWD/.venv/lib/python3.12/site-packages:$PYTHONPATH
+```
+
+`just source` prints the same three lines if you forget.
+
+
+## Running it
+
+`just --list` shows every recipe. The most common ones:
+
+| Recipe | What it does |
+|---|---|
+| `just launch` | Launch both robot server stacks + the camera node in one terminal. |
+| `just launch1` / `just launch2` | Launch one robot's server stack only. `launch1` also starts the camera node. |
+| `just run` | Start the Robot 1 orchestration node (the main pipeline). |
+| `just run2` | Start the Robot 2 orchestration node. |
+| `just rotate1` / `just rotate2` | Drive one robot through all five rotation primitives. Doesn't need the camera or the other robot. |
+| `just rotation-test` | Step through `_rotate_x_neg_90` then `_rotate_y_neg_90` interactively (Robot 1). |
+| `just open-schunk` / `just close-schunk` | Toggle Robot 1's gripper (needs `launch1`). |
+| `just open-onrobot` / `just close-onrobot` | Toggle Robot 2's gripper (needs `launch2`). |
+| `just conveyer-back` / `just conveyer-front` | Run a conveyor forward until Ctrl-C. |
+| `just kill` | Force-kill any orphaned ROS nodes. |
+
+Typical full-pipeline sequence: in one terminal `just launch`, then in two more terminals `just run` and `just run2`. Place a die in the bin in front of Robot 1 and the run starts.
+
+
+## Calibration
+
+Pip detection has three knobs that need tuning per camera/lighting setup. Both calibration scripts edit `robot1.py` and `robot2.py` in place so the tuned values survive re-builds.
+
+```sh
+just grab            # capture one frame via the running camera node
+just grab-sdk        # capture one frame directly via the SDK (camera node must NOT be running)
+just calibrate-hsv   # tune ROI + HSV thresholds + minimum contour area
+just calibrate-hough # tune HoughCircles (dp, minDist, param1, param2, min/max radius)
+```
+
+The calibration UI draws a sidebar inside the image with each parameter labelled and color-grouped — opencv-python's Linux Qt build mangles the native trackbar labels, so the sidebar is the source of truth.
+
+
+## License
+
+GPL v3 — same as upstream. See [`LICENSE.txt`](LICENSE.txt).
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/src/dual_fanuc/dual_fanuc/mv_camera_node.py
+++ b/src/dual_fanuc/dual_fanuc/mv_camera_node.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+mv_camera_node.py
+-----------------
+ROS2 node that captures frames from a MindVision GigE camera using the
+MindVision SDK (mvsdk) and publishes them as sensor_msgs/Image messages.
+
+Publishes:
+  /mv_camera/image_raw  (sensor_msgs/msg/Image, encoding: bgr8)
+
+Services:
+  /mv_camera/capture    (std_srvs/srv/Trigger) — grab one fresh frame on demand
+"""
+
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import Image
+from cv_bridge import CvBridge
+from std_srvs.srv import Trigger
+
+import numpy as np
+import cv2
+
+try:
+    import mvsdk
+except ImportError:
+    raise ImportError(
+        'MindVision SDK Python bindings (mvsdk) not found.\n'
+        'Ensure mvsdk.py is on your PYTHONPATH (via the .venv overlay).'
+    )
+
+PUBLISH_TOPIC   = '/mv_camera/image_raw'
+PUBLISH_RATE_HZ = 30.0
+
+
+class MVCameraNode(Node):
+
+    def __init__(self):
+        super().__init__('mv_camera_node')
+
+        self.bridge = CvBridge()
+        self.pub = self.create_publisher(Image, PUBLISH_TOPIC, 10)
+
+        try:
+            self._init_camera()
+            self.camera_ready = True
+        except RuntimeError as e:
+            self.get_logger().warn(f'Camera not available: {e}. Node will stay alive but publish nothing.')
+            self.camera_ready = False
+
+        self.create_service(Trigger, '/mv_camera/capture', self._capture_cb)
+        self.create_timer(1.0 / PUBLISH_RATE_HZ, self._publish_frame)
+
+        self.get_logger().info(f'MVCameraNode started — publishing on {PUBLISH_TOPIC} at {PUBLISH_RATE_HZ} Hz')
+
+    def _init_camera(self):
+        dev_list = mvsdk.CameraEnumerateDevice()
+        if len(dev_list) == 0:
+            raise RuntimeError('No MindVision cameras detected. Check GigE connection and adapter IP.')
+
+        # When the host has multiple NICs, the SDK enumerates the camera once per route
+        # ('<camera_ip>-<host_ip>'). Prefer the entry whose host_ip shares a /16 with the
+        # camera_ip (the route that actually carries data). Fall back to [0].
+        dev_info = dev_list[0]
+        for d in dev_list:
+            port = d.GetPortType()
+            if '-' not in port:
+                continue
+            cam_ip, host_ip = port.split('-', 1)
+            cam_oct, host_oct = cam_ip.split('.'), host_ip.split('.')
+            if len(cam_oct) >= 2 and len(host_oct) >= 2 and cam_oct[:2] == host_oct[:2]:
+                dev_info = d
+                break
+        self.get_logger().info(f'Opening camera: {dev_info.GetFriendlyName()} via {dev_info.GetPortType()}')
+
+        self.hCamera = mvsdk.CameraInit(dev_info, -1, -1)
+        cap = mvsdk.CameraGetCapability(self.hCamera)
+
+        if cap.sIspCapacity.bMonoSensor:
+            mvsdk.CameraSetIspOutFormat(self.hCamera, mvsdk.CAMERA_MEDIA_TYPE_MONO8)
+            self.mono = True
+        else:
+            mvsdk.CameraSetIspOutFormat(self.hCamera, mvsdk.CAMERA_MEDIA_TYPE_BGR8)
+            self.mono = False
+
+        mvsdk.CameraSetTriggerMode(self.hCamera, 0)   # continuous
+        mvsdk.CameraSetAeState(self.hCamera, 0)        # manual exposure
+        mvsdk.CameraSetExposureTime(self.hCamera, 30 * 1000)  # 30 ms
+
+        mvsdk.CameraPlay(self.hCamera)
+
+        buf_size = (cap.sResolutionRange.iWidthMax
+                    * cap.sResolutionRange.iHeightMax * 3)
+        self.pFrameBuffer = mvsdk.CameraAlignMalloc(buf_size, 16)
+
+        self.get_logger().info('Camera initialised and streaming.')
+
+    def _capture_cb(self, request, response):
+        if not self.camera_ready:
+            response.success = False
+            response.message = 'Camera not ready'
+            return response
+        ok = self._publish_frame(timeout_ms=2000)
+        response.success = ok
+        response.message = '' if ok else 'Frame grab timed out'
+        return response
+
+    def _publish_frame(self, timeout_ms=200):
+        if not self.camera_ready:
+            return False
+        try:
+            pRawData, FrameHead = mvsdk.CameraGetImageBuffer(self.hCamera, timeout_ms)
+            mvsdk.CameraImageProcess(self.hCamera, pRawData, self.pFrameBuffer, FrameHead)
+            mvsdk.CameraReleaseImageBuffer(self.hCamera, pRawData)
+
+            frame_data = (mvsdk.c_ubyte * FrameHead.uBytes).from_address(self.pFrameBuffer)
+            frame = np.frombuffer(frame_data, dtype=np.uint8)
+
+            if self.mono:
+                frame = frame.reshape((FrameHead.iHeight, FrameHead.iWidth))
+                frame = cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR)
+            else:
+                frame = frame.reshape((FrameHead.iHeight, FrameHead.iWidth, 3))
+
+            msg = self.bridge.cv2_to_imgmsg(frame, encoding='bgr8')
+            msg.header.stamp    = self.get_clock().now().to_msg()
+            msg.header.frame_id = 'mv_camera'
+            self.pub.publish(msg)
+            return True
+
+        except mvsdk.CameraException as e:
+            if e.error_code != mvsdk.CAMERA_STATUS_TIME_OUT:
+                self.get_logger().warn(f'Camera SDK error: {e}')
+            return False
+
+    def destroy_node(self):
+        self.get_logger().info('Shutting down camera...')
+        if self.camera_ready:
+            mvsdk.CameraStop(self.hCamera)
+            mvsdk.CameraAlignFree(self.pFrameBuffer)
+            mvsdk.CameraUnInit(self.hCamera)
+        super().destroy_node()
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = MVCameraNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/dual_fanuc/dual_fanuc/pip_lookup.py
+++ b/src/dual_fanuc/dual_fanuc/pip_lookup.py
@@ -1,0 +1,250 @@
+"""
+pip_lookup.py — Die orientation lookup tables for Robot 1 and Robot 2.
+"""
+
+# ── Pip 2 ──────────────────────────────────────────────────────────────────────
+PIP2_LOOKUP = {
+    # scan_top=1 
+    (1, 2): 'none',
+    (1, 3): 'rotate_y_pos90',
+    (1, 4): 'rotate_y_neg90',
+    (1, 5): 'flip_x_180',
+
+    # scan_top=2 
+    (2, 1): 'rotate_x_pos90',
+    (2, 3): 'rotate_x_pos90',
+    (2, 4): 'rotate_x_pos90',
+    (2, 6): 'rotate_x_pos90',
+
+    # scan_top=3
+    (3, 1): 'rotate_y_neg90',
+    (3, 2): 'none',
+    (3, 5): 'flip_x_180',
+    (3, 6): 'rotate_y_pos90',
+
+    # scan_top=4
+    (4, 1): 'rotate_y_pos90',
+    (4, 2): 'none',
+    (4, 5): 'flip_x_180',
+    (4, 6): 'rotate_y_neg90',
+
+    # scan_top=5 
+    (5, 1): 'rotate_x_neg90',
+    (5, 3): 'rotate_x_neg90',
+    (5, 4): 'rotate_x_neg90',
+    (5, 6): 'rotate_x_neg90',
+
+    # scan_top=6
+    (6, 2): 'none',
+    (6, 3): 'rotate_y_neg90',
+    (6, 4): 'rotate_y_pos90',
+    (6, 5): 'flip_x_180',
+}
+
+# ── Pip 4 ──────────────────────────────────────────────────────────────────────
+PIP4_LOOKUP = {
+    # scan_top=1
+    (1, 2): 'rotate_y_pos90',
+    (1, 3): 'flip_x_180',
+    (1, 4): 'none',
+    (1, 5): 'rotate_y_neg90',
+
+    # scan_top=2
+    (2, 1): 'rotate_y_neg90',
+    (2, 3): 'flip_x_180',
+    (2, 4): 'none',
+    (2, 6): 'rotate_y_pos90',
+
+    # scan_top=3 
+    (3, 1): 'rotate_x_neg90',
+    (3, 2): 'rotate_x_neg90',
+    (3, 5): 'rotate_x_neg90',
+    (3, 6): 'rotate_x_neg90',
+
+    # scan_top=4 
+    (4, 1): 'rotate_x_pos90',
+    (4, 2): 'rotate_x_pos90',
+    (4, 5): 'rotate_x_pos90',
+    (4, 6): 'rotate_x_pos90',
+
+    # scan_top=5
+    (5, 1): 'rotate_y_pos90',
+    (5, 3): 'flip_x_180',
+    (5, 4): 'none',
+    (5, 6): 'rotate_y_neg90',
+
+    # scan_top=6
+    (6, 2): 'rotate_y_neg90',
+    (6, 3): 'flip_x_180',
+    (6, 4): 'none',
+    (6, 5): 'rotate_y_pos90',
+}
+
+# ── Pip 6 ──────────────────────────────────────────────────────────────────────
+PIP6_LOOKUP = {
+    # scan_top=1
+    (1, 2): 'rotate_x_neg90',
+    (1, 3): 'rotate_x_neg90',
+    (1, 4): 'rotate_x_neg90',
+    (1, 5): 'rotate_x_neg90',
+
+    # scan_top=2
+    (2, 1): 'flip_x_180',
+    (2, 3): 'rotate_y_pos90',
+    (2, 4): 'rotate_y_neg90',
+    (2, 6): 'none',
+
+    # scan_top=3
+    (3, 1): 'flip_x_180',
+    (3, 2): 'rotate_y_neg90',
+    (3, 5): 'rotate_y_pos90',
+    (3, 6): 'none',
+
+    # scan_top=4
+    (4, 1): 'flip_x_180',
+    (4, 2): 'rotate_y_pos90',
+    (4, 5): 'rotate_y_neg90',
+    (4, 6): 'none',
+
+    # scan_top=5
+    (5, 1): 'flip_x_180',
+    (5, 3): 'rotate_y_neg90',
+    (5, 4): 'rotate_y_pos90',
+    (5, 6): 'none',
+
+    # scan_top=6 
+    (6, 2): 'rotate_x_pos90',
+    (6, 3): 'rotate_x_pos90',
+    (6, 4): 'rotate_x_pos90',
+    (6, 5): 'rotate_x_pos90',
+}
+
+# ── Pip 1 ──────────────────────────────────────────────────────────────────────
+
+PIP1_LOOKUP = {
+    # scan_top=1 
+    (1, 2): 'rotate_x_neg90',
+    (1, 3): 'rotate_x_neg90',
+    (1, 4): 'rotate_x_neg90',
+    (1, 5): 'rotate_x_neg90',
+
+    # scan_top=2
+    (2, 1): 'none',
+    (2, 3): 'rotate_y_pos90',
+    (2, 4): 'rotate_y_neg90',
+    (2, 6): 'flip_x_180',
+
+    # scan_top=3
+    (3, 1): 'none',
+    (3, 2): 'rotate_y_neg90',
+    (3, 5): 'rotate_y_pos90',
+    (3, 6): 'flip_x_180',
+
+    # scan_top=4
+    (4, 1): 'none',
+    (4, 2): 'rotate_y_pos90',
+    (4, 5): 'rotate_y_neg90',
+    (4, 6): 'flip_x_180',
+
+    # scan_top=5
+    (5, 1): 'none',
+    (5, 3): 'rotate_y_neg90',
+    (5, 4): 'rotate_y_pos90',
+    (5, 6): 'flip_x_180',
+
+    # scan_top=6 
+    (6, 2): 'rotate_x_pos90',
+    (6, 3): 'rotate_x_pos90',
+    (6, 4): 'rotate_x_pos90',
+    (6, 5): 'rotate_x_pos90',
+}
+
+# ── Pip 3 ──────────────────────────────────────────────────────────────────────
+PIP3_LOOKUP = {
+    # scan_top=1
+    (1, 2): 'rotate_y_pos90',
+    (1, 3): 'none',
+    (1, 4): 'flip_x_180',
+    (1, 5): 'rotate_y_neg90',
+
+    # scan_top=2
+    (2, 1): 'rotate_y_neg90',
+    (2, 3): 'none',
+    (2, 4): 'flip_x_180',
+    (2, 6): 'rotate_y_pos90',
+
+    # scan_top=3 
+    (3, 1): 'rotate_x_neg90',
+    (3, 2): 'rotate_x_neg90',
+    (3, 5): 'rotate_x_neg90',
+    (3, 6): 'rotate_x_neg90',
+
+    # scan_top=4 
+    (4, 1): 'rotate_x_pos90',
+    (4, 2): 'rotate_x_pos90',
+    (4, 5): 'rotate_x_pos90',
+    (4, 6): 'rotate_x_pos90',
+
+    # scan_top=5
+    (5, 1): 'rotate_y_pos90',
+    (5, 3): 'none',
+    (5, 4): 'flip_x_180',
+    (5, 6): 'rotate_y_neg90',
+
+    # scan_top=6
+    (6, 2): 'rotate_y_neg90',
+    (6, 3): 'none',
+    (6, 4): 'flip_x_180',
+    (6, 5): 'rotate_y_pos90',
+}
+
+# ── Pip 5 ──────────────────────────────────────────────────────────────────────
+PIP5_LOOKUP = {
+    # scan_top=1
+    (1, 2): 'flip_x_180',
+    (1, 3): 'rotate_y_pos90',
+    (1, 4): 'rotate_y_neg90',
+    (1, 5): 'none',
+
+    # scan_top=2 
+    (2, 1): 'rotate_x_pos90',
+    (2, 3): 'rotate_x_pos90',
+    (2, 4): 'rotate_x_pos90',
+    (2, 6): 'rotate_x_pos90',
+
+    # scan_top=3
+    (3, 1): 'rotate_y_neg90',
+    (3, 2): 'flip_x_180',
+    (3, 5): 'none',
+    (3, 6): 'rotate_y_pos90',
+
+    # scan_top=4
+    (4, 1): 'rotate_y_pos90',
+    (4, 2): 'flip_x_180',
+    (4, 5): 'none',
+    (4, 6): 'rotate_y_neg90',
+
+    # scan_top=5 
+    (5, 1): 'rotate_x_neg90',
+    (5, 3): 'rotate_x_neg90',
+    (5, 4): 'rotate_x_neg90',
+    (5, 6): 'rotate_x_neg90',
+
+    # scan_top=6
+    (6, 2): 'flip_x_180',
+    (6, 3): 'rotate_y_neg90',
+    (6, 4): 'rotate_y_pos90',
+    (6, 5): 'none',
+}
+
+# ── Dispatch ────────────────────────────────────────────────────────────────────
+_TABLES = {1: PIP1_LOOKUP, 2: PIP2_LOOKUP, 3: PIP3_LOOKUP,
+           4: PIP4_LOOKUP, 5: PIP5_LOOKUP, 6: PIP6_LOOKUP}
+
+
+def get_action(target_pip: int, scan_top: int, scan_after_xflip: int):
+    """Return the action string for (target_pip, scan_top, scan_after_xflip), or None."""
+    table = _TABLES.get(target_pip)
+    if table is None:
+        return None
+    return table.get((scan_top, scan_after_xflip))

--- a/src/dual_fanuc/dual_fanuc/robot1.py
+++ b/src/dual_fanuc/dual_fanuc/robot1.py
@@ -1,0 +1,659 @@
+#!/usr/bin/env python3
+"""
+
+Scan method:
+  1. Scan top face
+  2. Rotate +90° about x  (exposes adjacent face)
+  3. Scan new top face  (originally the right face)
+  (top, right) → lookup table → single rotation to bring pip 1,3, or 5 to top
+
+State published to /dual_fanuc/robot1_dice_location:
+  "rotating"         — actively manipulating die
+  "at_front_conveyer" — in hard-stop position, ready for Robot 2 to run conveyor
+  "on_conveyer"      — die placed on conveyor, Robot 2 can grab
+
+Standard die chirality: opposite faces sum to 7; with 1 on top and 2 facing viewer, 3 is on the right.
+"""
+
+import json
+import os
+import rclpy
+from rclpy.node import Node
+from rclpy.action import ActionClient
+
+from fanuc_interfaces.action import CartPose, JointPose, SchunkGripper, Conveyor
+from fanuc_interfaces.srv import SetSpeed
+
+from dual_fanuc.pip_lookup import get_action
+
+from sensor_msgs.msg import Image
+from std_msgs.msg import String
+from std_srvs.srv import Trigger
+from cv_bridge import CvBridge
+import cv2
+import numpy as np
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  Configuration
+# ══════════════════════════════════════════════════════════════════════════════
+
+ROBOT_NAME   = os.environ.get('ROBOT_1_NAME', 'robot1')
+ROBOT_2_NAME = os.environ.get('ROBOT_2_NAME', 'robot2')
+ROBOT_SPEED  = 300
+
+DICE_WIDTH        = 80.0
+APPROACH_OFFSET_Z = 2 * DICE_WIDTH   # 160 mm
+
+# Die pick position
+DICE_PICK = {'x': 469.0, 'y': -15.4, 'z': -178.5, 'w': 179.9, 'p': 0.0, 'r': 30.0}
+
+# Place position — die set down here for camera and all flip operations
+DICE_PLACE = {'x': 540.0, 'y': 399.12, 'z': -114.976, 'w': -179.9, 'p': 0.0, 'r': 120.0}
+
+# Conveyor drop position (back conveyor — odd pips)
+CONVEYOR_PLACE = {'x': -191.905, 'y': 667.664, 'z': 17.884, 'w': -179.9, 'p': 0.0, 'r': 120.0}
+
+# Front conveyor — hard stop where Robot 1 waits, and pick position
+FRONT_CONVEYOR_HARD_STOP = {'x': 144.786, 'y': 669.906,  'z': -13.595, 'w': 179.9, 'p': 0.0, 'r': 120.0}
+CONVEYOR_PICK_FRONT      = {'x': 144.786, 'y': 725.969,  'z':  14.437, 'w': 179.9, 'p': 0.0, 'r': 120.0}
+
+# Absolute side-grip position: die released here falls back to DICE_PLACE
+FLIP_X_GRAB = {'x': 540.0, 'y': 399.12, 'z': -143.407, 'w': 87.276, 'p': -59.453, 'r': -177.638}
+
+RETREAT_Z = DICE_WIDTH        # lift up 80 mm after releasing
+HOVER_WPR = (DICE_PLACE['w'], DICE_PLACE['p'], DICE_PLACE['r'])  # flat orientation above die
+
+CAMERA_TOPIC      = '/mv_camera/image_raw'
+R1_LOCATION_TOPIC = '/dual_fanuc/robot1_dice_location'
+R2_LOCATION_TOPIC = '/dual_fanuc/robot2_dice_location'
+IMAGE_SAVE_DIR    = os.path.expanduser('~/ClaudeDualFanuc2/tmp/')
+
+HSV_H_LOW  = 14;  HSV_S_LOW  = 100;  HSV_V_LOW  = 100
+HSV_H_HIGH = 35;  HSV_S_HIGH = 255;  HSV_V_HIGH = 255
+MIN_CONTOUR_AREA = 2500
+
+# Region of interest applied before HSV detection (camera-pixel coords).
+ROI_X1 = 0
+ROI_Y1 = 361
+ROI_X2 = 1280
+ROI_Y2 = 860
+
+HOUGH_DP       = 1.0
+HOUGH_MIN_DIST = 8
+HOUGH_PARAM1   = 8
+HOUGH_PARAM2   = 14
+HOUGH_MIN_R    = 0
+HOUGH_MAX_R    = 8
+
+VALID_PIP_COUNTS = frozenset(range(1, 7))
+XFLIP_Y_OFFSET   = 32.0  # mm die slides in +y after each x-flip
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  Node
+# ══════════════════════════════════════════════════════════════════════════════
+
+class Robot1Node(Node):
+
+    def __init__(self):
+        super().__init__('robot1')
+
+        ns = ROBOT_NAME
+        self.cart_ac      = ActionClient(self, CartPose,      f'/{ns}/cartesian_pose')
+        self.joints_ac    = ActionClient(self, JointPose,     f'/{ns}/joint_pose')
+        self.schunk_ac    = ActionClient(self, SchunkGripper, f'/{ns}/schunk_gripper')
+        self.conveyor_back_ac  = ActionClient(self, Conveyor, f'/{ns}/conveyor')            # odd  pips → Robot 2
+        self.conveyor_front_ac = ActionClient(self, Conveyor, f'/{ROBOT_2_NAME}/conveyor')  # even pips → Robot 1
+        self.speed_client = self.create_client(SetSpeed,      f'/{ns}/set_speed')
+
+        self.bridge       = CvBridge()
+        self.latest_image = None
+        self.create_subscription(Image, CAMERA_TOPIC, self._image_cb, 10)
+        self.capture_client = self.create_client(Trigger, '/mv_camera/capture')
+
+        self.die_place = dict(DICE_PLACE)
+
+        self.r1_location_pub  = self.create_publisher(String, R1_LOCATION_TOPIC, 10)
+        self.robot2_location  = ''
+        self.create_subscription(String, R2_LOCATION_TOPIC, self._r2_location_cb, 10)
+
+        # Flip-count tracking (count of physical die rotations per oriented pip; incremented in _rotate_x_pos_90)
+        self.target_pip   = None
+        self.flip_count   = 0
+        self.flip_log     = {}
+        self.flip_log_pub = self.create_publisher(String, f'/{ns}/flip_log', 10)
+
+        self.get_logger().info('Waiting for action servers and camera...')
+        # Essential for any operation — block until available.
+        self.cart_ac.wait_for_server()
+        self.joints_ac.wait_for_server()
+        self.schunk_ac.wait_for_server()
+        # Optional — only needed for full pipeline. Warn and continue so rotate-only tests work
+        # without launch2 / a working camera.
+        for ac, label in (
+            (self.conveyor_back_ac,  f'/{ns}/conveyor (back)'),
+            (self.conveyor_front_ac, f'/{ROBOT_2_NAME}/conveyor (front)'),
+        ):
+            if not ac.wait_for_server(timeout_sec=5.0):
+                self.get_logger().warn(f'Action server not available after 5 s: {label} — continuing.')
+        if not self.capture_client.wait_for_service(timeout_sec=5.0):
+            self.get_logger().warn('Camera capture service /mv_camera/capture not available after 5 s — continuing.')
+        self.get_logger().info(f'Robot 1 ready — namespace: /{ns}')
+
+    # ── Camera ────────────────────────────────────────────────────────────────
+
+    def _r2_location_cb(self, msg: String):
+        self.robot2_location = msg.data
+
+    def _publish_location(self, state: str):
+        msg = String()
+        msg.data = state
+        self.r1_location_pub.publish(msg)
+        self.get_logger().info(f'robot1_dice_location: {state}')
+
+    def _wait_for_robot2(self, *states: str):
+        """Wait until robot2_location matches any given state. Returns the matched state."""
+        label = ' or '.join(states)
+        self.get_logger().info(f'Waiting for robot2_dice_location: {label}')
+        while rclpy.ok():
+            rclpy.spin_once(self, timeout_sec=0.1)
+            if self.robot2_location in states:
+                return self.robot2_location
+
+    def _publish_flip_log(self):
+        msg = String()
+        msg.data = json.dumps({str(k): v for k, v in self.flip_log.items()})
+        self.flip_log_pub.publish(msg)
+
+    def _print_summary(self):
+        total = sum(self.flip_log.values())
+        lines = ['═══ Robot 1 flip summary ═══']
+        for pip in sorted(self.flip_log):
+            lines.append(f'  pip {pip}: {self.flip_log[pip]} flip(s)')
+        lines.append(f'  Robot 1 total: {total}')
+        for line in lines:
+            self.get_logger().info(line)
+
+    def _image_cb(self, msg):
+        self.latest_image = self.bridge.imgmsg_to_cv2(msg, desired_encoding='bgr8')
+
+    def _capture_image(self):
+        self.latest_image = None
+        future = self.capture_client.call_async(Trigger.Request())
+        rclpy.spin_until_future_complete(self, future)
+        if not future.result().success:
+            self.get_logger().error('Camera capture service returned failure.')
+            return None
+        deadline_ns = self.get_clock().now().nanoseconds + int(3.0 * 1e9)
+        while self.latest_image is None:
+            rclpy.spin_once(self, timeout_sec=0.05)
+            if self.get_clock().now().nanoseconds > deadline_ns:
+                self.get_logger().error('Timed out waiting for camera frame.')
+                return None
+        return self.latest_image.copy()
+
+    def _crop_die(self, image):
+        image = image[ROI_Y1:ROI_Y2, ROI_X1:ROI_X2]   # narrow search to ROI
+        hsv  = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
+        mask = cv2.inRange(hsv,
+                           np.array([HSV_H_LOW,  HSV_S_LOW,  HSV_V_LOW]),
+                           np.array([HSV_H_HIGH, HSV_S_HIGH, HSV_V_HIGH]))
+        kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (5, 5))
+        mask   = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel)
+        mask   = cv2.morphologyEx(mask, cv2.MORPH_OPEN,  kernel)
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        contours = [c for c in contours if cv2.contourArea(c) >= MIN_CONTOUR_AREA]
+        if not contours:
+            self.get_logger().warn('HSV crop: no region above MIN_CONTOUR_AREA — using full image.')
+            return image
+        # Match calibrate-hsv exactly: fill the chosen contour, bitwise_and with the
+        # ROI so everything outside the die contour goes black, then crop.
+        c = max(contours, key=cv2.contourArea)
+        die_mask = np.zeros(image.shape[:2], dtype=np.uint8)
+        cv2.drawContours(die_mask, [c], -1, 255, thickness=cv2.FILLED)
+        masked = cv2.bitwise_and(image, image, mask=die_mask)
+        x, y, w, h = cv2.boundingRect(c)
+        pad = 10
+        return masked[max(0, y-pad):min(image.shape[0], y+h+pad),
+                      max(0, x-pad):min(image.shape[1], x+w+pad)]
+
+    def _count_pips(self, image):
+        gray    = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        blurred = cv2.GaussianBlur(gray, (11, 11), 2)
+        circles = cv2.HoughCircles(blurred, cv2.HOUGH_GRADIENT,
+                                   dp=HOUGH_DP, minDist=HOUGH_MIN_DIST,
+                                   param1=HOUGH_PARAM1, param2=HOUGH_PARAM2,
+                                   minRadius=HOUGH_MIN_R, maxRadius=HOUGH_MAX_R)
+        debug = image.copy()
+        if circles is None:
+            cv2.putText(debug, 'No pips detected', (20, 40),
+                        cv2.FONT_HERSHEY_SIMPLEX, 1.0, (0, 0, 255), 2)
+            return 0, debug
+        for (cx, cy, r) in np.round(circles[0]).astype(int):
+            cv2.circle(debug, (cx, cy), r, (0, 255, 0), 2)
+            cv2.circle(debug, (cx, cy), 3, (0, 0, 255), -1)
+        count = len(circles[0])
+        cv2.putText(debug, f'Pips: {count}', (20, 40),
+                    cv2.FONT_HERSHEY_SIMPLEX, 1.0, (0, 255, 0), 2)
+        return count, debug
+
+    # ── Motion primitives ─────────────────────────────────────────────────────
+
+    def _send_goal(self, client, goal):
+        future = client.send_goal_async(goal)
+        rclpy.spin_until_future_complete(self, future)
+        gh = future.result()
+        if not gh.accepted:
+            self.get_logger().error('Goal rejected.')
+            return None
+        rf = gh.get_result_async()
+        rclpy.spin_until_future_complete(self, rf)
+        return rf.result().result
+
+    def _move_cart(self, x, y, z, w=200.0, p=200.0, r=200.0):
+        goal = CartPose.Goal()
+        goal.x, goal.y, goal.z = float(x), float(y), float(z)
+        goal.w, goal.p, goal.r = float(w), float(p), float(r)
+        res = self._send_goal(self.cart_ac, goal)
+        return res is not None and res.success
+
+    def _move_joints(self, j1, j2, j3, j4, j5, j6):
+        goal = JointPose.Goal()
+        goal.joint1, goal.joint2, goal.joint3 = float(j1), float(j2), float(j3)
+        goal.joint4, goal.joint5, goal.joint6 = float(j4), float(j5), float(j6)
+        res = self._send_goal(self.joints_ac, goal)
+        return res is not None and res.success
+
+    def _schunk(self, command):
+        goal = SchunkGripper.Goal()
+        goal.command = command
+        res = self._send_goal(self.schunk_ac, goal)
+        return res is not None and res.success
+
+    def _conveyor(self, command, pip):
+        """Send command to back conveyor (odd pip) or front conveyor (even pip)."""
+        ac    = self.conveyor_back_ac  if pip % 2 != 0 else self.conveyor_front_ac
+        label = 'back'                 if pip % 2 != 0 else 'front'
+        self.get_logger().info(f'Conveyor {label} ({command}) — pip {pip}')
+        goal = Conveyor.Goal()
+        goal.command = command
+        res = self._send_goal(ac, goal)
+        return res is not None and res.success
+
+    def _place_on_conveyor(self, pip):
+        """Pick die from DICE_PLACE and place on back (odd pip) or front (even pip) conveyor."""
+        cp    = CONVEYOR_PLACE
+        pl    = self.die_place
+        label = 'back' if pip % 2 != 0 else 'front'
+
+        lift_z = pl['z'] + 3 * DICE_WIDTH   # clearance for transit to conveyor
+
+        self.get_logger().info(f'Placing pip {pip} on {label} conveyor.')
+        self._schunk('open')
+        self._move_cart(pl['x'], pl['y'], pl['z'] + APPROACH_OFFSET_Z, pl['w'], pl['p'], pl['r'])  # approach
+        self._move_cart(pl['x'], pl['y'], pl['z'],                      pl['w'], pl['p'], pl['r'])  # grab
+        self._schunk('close')
+        self._move_cart(pl['x'], pl['y'], lift_z,                       pl['w'], pl['p'], pl['r'])  # lift high
+        self._move_cart(cp['x'], cp['y'], lift_z,                       cp['w'], cp['p'], cp['r'])  # transit above conveyor
+        self._move_cart(cp['x'], cp['y'], cp['z'],                      cp['w'], cp['p'], cp['r'])  # lower to conveyor
+        self._schunk('open')
+        self._move_cart(cp['x'], cp['y'], cp['z'] + RETREAT_Z,         cp['w'], cp['p'], cp['r'])  # retreat
+
+        self._publish_location('on_conveyer')
+        self._wait_for_robot2('at_back_conveyer')
+        self.get_logger().info('Robot 2 in position — running conveyor 10 seconds...')
+        self._conveyor('forward', pip)
+        import time; time.sleep(10)
+        self._conveyor('stop', pip)
+        self._publish_location('conveyer_done')
+        self.get_logger().info('Done.')
+
+    def _set_speed(self, speed=ROBOT_SPEED):
+        if not self.speed_client.wait_for_service(timeout_sec=3.0):
+            self.get_logger().warn('set_speed service not available.')
+            return
+        req = SetSpeed.Request()
+        req.speed = speed
+        future = self.speed_client.call_async(req)
+        rclpy.spin_until_future_complete(self, future)
+
+    def go_home(self):
+        self.get_logger().info('Going home...')
+        self._move_joints(0, 0, 0, 0, -90, 30)
+        self._schunk('open')
+
+    # ── X-axis flip ───────────────────────────────────────────────────────────
+    # Top-down pick from current die position, transit to absolute FLIP_X_GRAB, release.
+    # Die tips over and lands ~XFLIP_Y_OFFSET (+y) from DICE_PLACE — self.die_place is updated to track it.
+
+    def _rotate_x_pos_90(self):
+        """Rotate die +90° about x: pick top-down at current die position, carry to FLIP_X_GRAB, release.
+        Updates self.die_place y by XFLIP_Y_OFFSET after each flip.
+        Counts as one physical flip; wrappers (flip_x_180, rotate_x_neg_90, y rotates) compose."""
+        self.flip_count += 1
+        dp = self.die_place
+        fg = FLIP_X_GRAB
+        dw, dpw, dr = dp['w'], dp['p'], dp['r']
+
+        self._move_cart(dp['x'], dp['y'], dp['z'] + 2*DICE_WIDTH, dw, dpw, dr)              # hover above
+        self._schunk('open')
+        self._move_cart(dp['x'], dp['y'], dp['z'],               dw, dpw, dr)               # lower to grab
+        self._schunk('close')
+        self._move_cart(dp['x'], dp['y'], dp['z'] + DICE_WIDTH,  dw, dpw, dr)               # lift
+        self._move_cart(fg['x'], fg['y'], fg['z'] + DICE_WIDTH,  fg['w'], fg['p'], fg['r']) # transit + rotate wrist
+        self._move_cart(fg['x'], fg['y'], fg['z'],               fg['w'], fg['p'], fg['r']) # lower to flip position
+        self._schunk('open')
+        self.die_place = dict(DICE_PLACE, y=DICE_PLACE['y'] + XFLIP_Y_OFFSET)              # die slides +y by XFLIP_Y_OFFSET after each x-flip
+        self._move_cart(fg['x'], fg['y'] - DICE_WIDTH, fg['z'],  fg['w'], fg['p'], fg['r']) # retreat −y
+
+    def _rotate_x_neg_90(self):
+        """Rotate die −90° about x via three consecutive +90° rotations."""
+        self.get_logger().info('Rotate x−90: step 1 of 3')
+        self._rotate_x_pos_90()
+        self.get_logger().info('Rotate x−90: step 2 of 3')
+        self._rotate_x_pos_90()
+        self.get_logger().info('Rotate x−90: step 3 of 3')
+        self._rotate_x_pos_90()
+
+    def _flip_x_180(self):
+        """Flip die 180° about x via two +90° rotations."""
+        self.get_logger().info('Flip x-axis: step 1 of 2')
+        self._rotate_x_pos_90()
+        self.get_logger().info('Flip x-axis: step 2 of 2')
+        self._rotate_x_pos_90()
+        self.get_logger().info('Flip x-axis: complete')
+
+    # ── Y-axis flip (J6 rotation then single X-pos-90 primitive) ─────────────
+    # Yaw the die 90° about Z using J6, lower to table, then do a single _rotate_x_pos_90.
+    # Net effect: ±90° about y. The trailing x-flip slides the die +y by XFLIP_Y_OFFSET (tracked in self.die_place).
+
+    def _rotate_y_neg_90(self):
+        """Rotate die −90° about y: J6 +90° at current die position, then _rotate_x_pos_90."""
+        dp = self.die_place
+        dw, dpw, dr = dp['w'], dp['p'], dp['r']
+        dr_rot = (dr + 90.0 + 180.0) % 360.0 - 180.0
+
+        self._move_cart(dp['x'], dp['y'], dp['z'] + 2*DICE_WIDTH, dw, dpw, dr)
+        self._schunk('open')
+        self._move_cart(dp['x'], dp['y'], dp['z'],                dw, dpw, dr)     # lower to grab
+        self._schunk('close')
+        self._move_cart(dp['x'], dp['y'], dp['z'] + DICE_WIDTH,   dw, dpw, dr)     # lift
+        self._move_cart(dp['x'], dp['y'], dp['z'] + DICE_WIDTH,   dw, dpw, dr_rot) # J6 +90°
+        self._move_cart(dp['x'], dp['y'], dp['z'],                dw, dpw, dr_rot) # lower
+        self._schunk('open')
+        self._move_cart(dp['x'], dp['y'], dp['z'] + DICE_WIDTH,   dw, dpw, dr_rot)
+        self._move_cart(dp['x'], dp['y'], dp['z'] + 2*DICE_WIDTH, dw, dpw, dr)     # J6 back
+        self._rotate_x_pos_90()
+
+    def _rotate_y_pos_90(self):
+        """Rotate die +90° about y: J6 −90° at current die position, then _rotate_x_pos_90."""
+        dp = self.die_place
+        dw, dpw, dr = dp['w'], dp['p'], dp['r']
+        dr_rot = (dr - 90.0 + 180.0) % 360.0 - 180.0
+
+        self._move_cart(dp['x'], dp['y'], dp['z'] + 2*DICE_WIDTH, dw, dpw, dr)
+        self._schunk('open')
+        self._move_cart(dp['x'], dp['y'], dp['z'],                dw, dpw, dr)     # lower to grab
+        self._schunk('close')
+        self._move_cart(dp['x'], dp['y'], dp['z'] + DICE_WIDTH,   dw, dpw, dr)     # lift
+        self._move_cart(dp['x'], dp['y'], dp['z'] + DICE_WIDTH,   dw, dpw, dr_rot) # J6 −90°
+        self._move_cart(dp['x'], dp['y'], dp['z'],                dw, dpw, dr_rot) # lower
+        self._schunk('open')
+        self._move_cart(dp['x'], dp['y'], dp['z'] + DICE_WIDTH,   dw, dpw, dr_rot)
+        self._move_cart(dp['x'], dp['y'], dp['z'] + 2*DICE_WIDTH, dw, dpw, dr)     # J6 back
+        self._rotate_x_pos_90()
+
+    def _flip_y_180(self):
+        """Flip die 180° about y via two −90° rotations."""
+        self.get_logger().info('Flip y-axis: step 1 of 2')
+        self._rotate_y_neg_90()
+        self.get_logger().info('Flip y-axis: step 2 of 2')
+        self._rotate_y_neg_90()
+        self.get_logger().info('Flip y-axis: complete')
+
+    # ── Main sequence ─────────────────────────────────────────────────────────
+
+    def _pick_and_place(self):
+        """Pick die from DICE_PICK, place at DICE_PLACE, retreat for camera."""
+        pk = DICE_PICK
+        pl = DICE_PLACE
+
+        self._schunk('open')
+        self._move_cart(pk['x'], pk['y'], pk['z'] + APPROACH_OFFSET_Z,
+                        pk['w'], pk['p'], pk['r'])
+        self._move_cart(pk['x'], pk['y'], pk['z'],
+                        pk['w'], pk['p'], pk['r'])
+        self._schunk('close')
+        self._move_cart(pk['x'], pk['y'], pk['z'] + APPROACH_OFFSET_Z,
+                        pk['w'], pk['p'], pk['r'])
+        self._move_cart(pl['x'], pl['y'], pl['z'] + APPROACH_OFFSET_Z,
+                        pl['w'], pl['p'], pl['r'])
+        self._move_cart(pl['x'], pl['y'], pl['z'],
+                        pl['w'], pl['p'], pl['r'])
+        self._schunk('open')
+        self._move_cart(pl['x'], pl['y'], pl['z'] + RETREAT_Z,
+                        pl['w'], pl['p'], pl['r'])
+
+    def _capture_face(self, die_x, die_y, die_z, label='Face'):
+        """Hover → retreat −Y → capture → count pips (logged immediately) → return to hover. Returns (pip_count, debug)."""
+        self._move_cart(die_x, die_y,                   die_z + RETREAT_Z, *HOVER_WPR)  # hover
+        self._move_cart(die_x, die_y - 3 * DICE_WIDTH,  die_z + RETREAT_Z, *HOVER_WPR)  # retreat
+        image = self._capture_image()
+        if image is None:
+            self.get_logger().error(f'{label}: camera capture failed.')
+            self._move_cart(die_x, die_y, die_z + RETREAT_Z, *HOVER_WPR)  # return to hover
+            return 0, None
+        slug = label.lower().replace(' ', '_')
+        cv2.imwrite(f'{IMAGE_SAVE_DIR}{slug}_full.png', image)
+        cropped = self._crop_die(image)
+        pip_count, debug = self._count_pips(cropped)
+        self.get_logger().info(f'Expected Pip: {self.target_pip} ---- Saw Pip: {pip_count}')
+        self._move_cart(die_x, die_y,                   die_z + RETREAT_Z, *HOVER_WPR)  # return to hover
+        return pip_count, debug
+
+    def _is_valid_pip(self, count, label):
+        if count not in VALID_PIP_COUNTS:
+            self.get_logger().error(
+                f'{label}: invalid pip count {count} (must be 1–6). '
+                f'Check camera, lighting, or Hough calibration. Aborting.')
+            return False
+        return True
+
+    def _save_debug(self, debug_imgs):
+        for name, img in debug_imgs.items():
+            if img is not None:
+                cv2.imwrite(f'{IMAGE_SAVE_DIR}{name}.png', img)
+
+    def _grab_from_front_conveyor(self):
+        """Pick die from front conveyor (placed by Robot 2), transport to DICE_PLACE."""
+        cp  = CONVEYOR_PICK_FRONT
+        pl  = DICE_PLACE
+        fhs = FRONT_CONVEYOR_HARD_STOP
+        hover_z = cp['z'] + 2 * DICE_WIDTH
+
+        self._schunk('open')
+        self._move_cart(fhs['x'], fhs['y'] - DICE_WIDTH, fhs['z'],  fhs['w'], fhs['p'], fhs['r'])  # retreat −y
+        self._move_cart(fhs['x'], fhs['y'] - DICE_WIDTH, hover_z,   fhs['w'], fhs['p'], fhs['r'])  # rise up
+        self._move_cart(cp['x'],  cp['y'],               hover_z,   cp['w'],  cp['p'],  cp['r'])   # above die
+        self._move_cart(cp['x'],  cp['y'],               cp['z'],   cp['w'],  cp['p'],  cp['r'])   # lower to pick
+        self._schunk('close')
+        self._move_cart(cp['x'],  cp['y'],               hover_z,   cp['w'],  cp['p'],  cp['r'])   # rise
+        self._move_cart(pl['x'],  pl['y'],               hover_z,   pl['w'],  pl['p'],  pl['r'])   # transit
+        self._move_cart(pl['x'],  pl['y'],               pl['z'],   pl['w'],  pl['p'],  pl['r'])   # lower
+        self._schunk('open')
+        self._move_cart(pl['x'],  pl['y'],               pl['z'] + RETREAT_Z, pl['w'],  pl['p'],  pl['r'])
+
+    def _scan_and_orient(self, target_pip):
+        """Two-scan orient: scan top, x-flip, scan again, lookup action, apply. Returns True on success."""
+        self.target_pip = target_pip
+        self.flip_count = 0
+        self.die_place = dict(DICE_PLACE)  # die freshly placed at DICE_PLACE; reset tracker
+        x, y, z = DICE_PLACE['x'], DICE_PLACE['y'], DICE_PLACE['z']
+        debug_imgs = {}
+
+        # ── Scan 1: top face ──────────────────────────────────────────────────
+        face_top, dbg = self._capture_face(x, y, z, 'scan1_top')
+        debug_imgs['scan1_top'] = dbg
+        if not self._is_valid_pip(face_top, 'Scan 1'):
+            self._save_debug(debug_imgs)
+            return False
+
+        if face_top == target_pip:
+            self.get_logger().info(f'Pip {target_pip} already on top — no rotation needed.')
+            self.flip_log[target_pip] = self.flip_count
+            self._publish_flip_log()
+            self._save_debug(debug_imgs)
+            return True
+
+        # ── X-flip to expose adjacent face ────────────────────────────────────
+        self._publish_location('rotating')
+        self._rotate_x_pos_90()
+
+        # ── Scan 2: face now on top after x-flip ──────────────────────────────
+        face_left, dbg = self._capture_face(x, y, z, 'scan2_left')
+        debug_imgs['scan2_left'] = dbg
+        if not self._is_valid_pip(face_left, 'Scan 2'):
+            self._save_debug(debug_imgs)
+            return False
+
+        # ── Lookup + apply corrective rotation ────────────────────────────────
+        action = get_action(target_pip, face_top, face_left)
+        if action is None:
+            self.get_logger().error(
+                f'No lookup entry for pip {target_pip}: top={face_top} left={face_left}. '
+                f'Check detection or die chirality.')
+            self._save_debug(debug_imgs)
+            return False
+
+        self.get_logger().info(
+            f'Pip {target_pip} — orientation ({face_top},{face_left}) → action: {action}')
+
+        if action == 'none':
+            pass
+        elif action == 'rotate_y_neg90':
+            self._rotate_y_neg_90()
+        elif action == 'rotate_y_pos90':
+            self._rotate_y_pos_90()
+        elif action == 'flip_x_180':
+            self._flip_x_180()
+        elif action == 'rotate_x_neg90':
+            self._rotate_x_neg_90()
+        elif action == 'rotate_x_pos90':
+            self._rotate_x_pos_90()
+
+        # ── Pre-conveyor verification scan ────────────────────────────────────
+        dp = self.die_place
+        verify_count, dbg = self._capture_face(dp['x'], dp['y'], dp['z'], 'verify_top')
+        debug_imgs['verify_top'] = dbg
+        if verify_count != target_pip:
+            self.get_logger().error(
+                f'Pre-conveyor verification FAILED — expected pip {target_pip} on top, '
+                f'camera sees {verify_count}. Aborting placement.')
+            self._save_debug(debug_imgs)
+            return False
+        self.get_logger().info(f'Pre-conveyor verification: pip {target_pip} confirmed on top.')
+
+        self.flip_log[target_pip] = self.flip_count
+        self._publish_flip_log()
+        self._save_debug(debug_imgs)
+        return True
+
+    def run(self):
+        self._set_speed()
+        self.go_home()
+        self._publish_location('home')
+
+        while rclpy.ok():
+            # ── Pip 1: pick fresh die from pile ───────────────────────────────
+            self._pick_and_place()
+            if not self._scan_and_orient(1):
+                self.get_logger().error('Failed to orient pip 1 — restarting cycle.')
+                continue
+            self._place_on_conveyor(1)   # → back conveyor, runs conveyor, publishes "conveyer_done"
+
+            # ── Pip 3: Robot 2 placed pip 2 on front conveyor ────────────────
+            self.robot2_location = ''
+            self._wait_for_robot2('on_conveyer')
+            self.robot2_location = ''
+            fhs = FRONT_CONVEYOR_HARD_STOP
+            self.get_logger().info('Moving to front conveyor hard stop...')
+            self._move_cart(fhs['x'], fhs['y'], fhs['z'], fhs['w'], fhs['p'], fhs['r'])
+            self._schunk('close')
+            self._publish_location('at_front_conveyer')
+            self._wait_for_robot2('front_conveyer_done')
+            self.robot2_location = ''
+            self._grab_from_front_conveyor()
+            if not self._scan_and_orient(3):
+                self.get_logger().error('Failed to orient pip 3 — restarting cycle.')
+                continue
+            self._place_on_conveyor(3)   # → back conveyor
+
+            # ── Pip 5: Robot 2 placed pip 4 on front conveyor ────────────────
+            self.robot2_location = ''
+            self._wait_for_robot2('on_conveyer')
+            self.robot2_location = ''
+            self.get_logger().info('Moving to front conveyor hard stop...')
+            self._move_cart(fhs['x'], fhs['y'], fhs['z'], fhs['w'], fhs['p'], fhs['r'])
+            self._schunk('close')
+            self._publish_location('at_front_conveyer')
+            self._wait_for_robot2('front_conveyer_done')
+            self.robot2_location = ''
+            self._grab_from_front_conveyor()
+            if not self._scan_and_orient(5):
+                self.get_logger().error('Failed to orient pip 5 — restarting cycle.')
+                continue
+            self._place_on_conveyor(5)   # → back conveyor
+
+            # ── Wait for Robot 2 to finish pip 6 (or signal run_complete) ────
+            self.robot2_location = ''
+            matched = self._wait_for_robot2('on_conveyer', 'run_complete')
+            self.robot2_location = ''
+            if matched == 'run_complete':
+                self.get_logger().info('Robot 2 signalled run_complete — finishing run.')
+                self._print_summary()
+                self.go_home()
+                break
+            self.get_logger().info('Full 6-pip cycle complete — starting next die.')
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = Robot1Node()
+    node.run()
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+def main_rotate(args=None):
+    """Pick die from home, place at DICE_PLACE, then run all five rotation primitives."""
+    rclpy.init(args=args)
+    node = Robot1Node()
+    node._set_speed()
+
+    node.go_home()
+    node._pick_and_place()
+
+    node.get_logger().info('Rotating about x positive 90 degrees')
+    node._rotate_x_pos_90()
+
+    node.get_logger().info('Rotating about y positive 90 degrees')
+    node._rotate_y_pos_90()
+
+    node.get_logger().info('Rotating about x negative 90 degrees')
+    node._rotate_x_neg_90()
+
+    node.get_logger().info('Rotating about y negative 90 degrees')
+    node._rotate_y_neg_90()
+
+    node.get_logger().info('Flipping about x 180 degrees')
+    node._flip_x_180()
+
+    node.go_home()
+    node.get_logger().info('--- Rotate test complete ---')
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/dual_fanuc/dual_fanuc/robot2.py
+++ b/src/dual_fanuc/dual_fanuc/robot2.py
@@ -1,0 +1,705 @@
+#!/usr/bin/env python3
+"""
+
+Scan method:
+  1. Scan top face  (should be pip 1 — robot1 guarantee)
+  2. Rotate −90° about x  (exposes adjacent face)
+  3. Scan new top face  (originally the left face)
+  (top, left) → lookup table → single rotation to bring pip 2,4, or 6 to top
+
+State published to /dual_fanuc/robot2_dice_location:
+  "rotating"         — actively manipulating die
+  "at_back_conveyer" — in hard-stop position, ready for Robot 1 to run conveyor
+  "on_conveyer"      — die placed on conveyor, Robot 1 can grab
+
+Standard die chirality: opposite faces sum to 7; with 1 on top and 2 facing viewer, 3 is on the right.
+"""
+
+import json
+import os
+import time
+
+import rclpy
+from rclpy.node import Node
+from rclpy.action import ActionClient
+from std_msgs.msg import String
+from sensor_msgs.msg import Image
+from std_srvs.srv import Trigger
+from cv_bridge import CvBridge
+import cv2
+import numpy as np
+
+from fanuc_interfaces.action import CartPose, JointPose, OnRobotGripper, Conveyor
+from fanuc_interfaces.srv import SetSpeed
+
+from dual_fanuc.pip_lookup import get_action
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  Configuration
+# ══════════════════════════════════════════════════════════════════════════════
+
+ROBOT_NAME   = os.environ.get('ROBOT_2_NAME', 'robot2')
+ROBOT_1_NAME = os.environ.get('ROBOT_1_NAME', 'robot1')
+ROBOT_SPEED = 300  # mm/s
+DICE_WIDTH  = 80.0
+
+R1_LOCATION_TOPIC = '/dual_fanuc/robot1_dice_location'
+R2_LOCATION_TOPIC = '/dual_fanuc/robot2_dice_location'
+
+HOME_JOINTS    = (0, 0, 0, 0, -90, 0)
+CONVEYOR_PICK  = {'x': -221.1,  'y': -693.88, 'z':  60.747, 'w': -179.9, 'p': 0.0, 'r': -90.0}
+CONVEYOR_HARD_STOP = {'x': -221.1, 'y': -634.93, 'z': 60.747, 'w': -179.9, 'p': 0.0, 'r': -90.0}
+DICE_PLACE     = {'x':  450.52, 'y': -375.16-150, 'z': -76.28, 'w': -179.9, 'p': 0.0, 'r': -90.0}
+# Terminal/end position — Robot 2 grabs from here in `just rotate2` and drops here after pip 6.
+DICE_END       = {'x':  462.65, 'y':  -12.938, 'z': -115.594, 'w': 179.9, 'p': 0.0, 'r': -90.0}
+# ── X-flip (−90° about x) ────────────────────────────────────────────────────
+# Approach from +y by DICE_WIDTH
+FLIP_X_GRAB = {'x': 450.52, 'y': -300.6-150, 'z': -159.873, 'w': 165.474, 'p': -89.89, 'r': -75.278}
+
+CONVEYOR_PLACE_FRONT = dict(CONVEYOR_PICK, x=136.0)  # front conveyor; shares y/z/w/p/r with back
+
+# OnRobot gripper
+ONROBOT_OPEN_WIDTH  = 100   # mm
+ONROBOT_CLOSE_WIDTH = 5     # mm
+ONROBOT_FORCE       = 40    # N
+
+# Camera
+CAMERA_TOPIC   = '/mv_camera/image_raw'
+IMAGE_SAVE_DIR = os.path.expanduser('~/ClaudeDualFanuc2/tmp/')
+
+HSV_H_LOW  = 14;  HSV_S_LOW  = 100;  HSV_V_LOW  = 100
+HSV_H_HIGH = 35;  HSV_S_HIGH = 255;  HSV_V_HIGH = 255
+MIN_CONTOUR_AREA = 2500
+
+# Region of interest applied before HSV detection (camera-pixel coords).
+ROI_X1 = 0
+ROI_Y1 = 361
+ROI_X2 = 1280
+ROI_Y2 = 860
+
+HOUGH_DP     = 1.0
+HOUGH_MIN_DIST = 8
+HOUGH_PARAM1 = 8
+HOUGH_PARAM2 = 14
+HOUGH_MIN_R  = 0
+HOUGH_MAX_R  = 8
+
+VALID_PIP_COUNTS = frozenset(range(1, 7))  # {1, 2, 3, 4, 5, 6}
+
+# Lookup tables live in pip_lookup.py (PIP2_LOOKUP, PIP4_LOOKUP, PIP6_LOOKUP).
+# Use get_action(target_pip, scan_top, scan_after_xflip) to query them.
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  Node
+# ══════════════════════════════════════════════════════════════════════════════
+
+class Robot2Node(Node):
+
+    def __init__(self):
+        super().__init__('robot2')
+
+        ns = ROBOT_NAME
+        self.cart_ac      = ActionClient(self, CartPose,       f'/{ns}/cartesian_pose')
+        self.joints_ac    = ActionClient(self, JointPose,      f'/{ns}/joint_pose')
+        self.onrobot_ac   = ActionClient(self, OnRobotGripper, f'/{ns}/onrobot_gripper')
+        self.conveyor_ac  = ActionClient(self, Conveyor,       f'/{ns}/conveyor')
+        self.speed_client = self.create_client(SetSpeed,       f'/{ns}/set_speed')
+
+        self.bridge       = CvBridge()
+        self.latest_image = None
+        self.create_subscription(Image, CAMERA_TOPIC, self._image_cb, 10)
+        self.capture_client = self.create_client(Trigger, '/mv_camera/capture')
+
+        self.r2_location_pub = self.create_publisher(String, R2_LOCATION_TOPIC, 10)
+        self.robot1_location = ''
+        self.create_subscription(String, R1_LOCATION_TOPIC, self._r1_location_cb, 10)
+
+        # Flip-count tracking (physical die rotations per oriented pip; incremented in _rotate_x_neg_90)
+        # plus cross-robot visibility via /flip_log topics.
+        self.target_pip      = None
+        self.flip_count      = 0
+        self.flip_log        = {}
+        self.robot1_flip_log = {}
+        self.last_gripper_width = None  # skips redundant gripper commands
+        self.flip_log_pub    = self.create_publisher(String, f'/{ns}/flip_log', 10)
+        self.create_subscription(String, f'/{ROBOT_1_NAME}/flip_log',
+                                 self._r1_flip_log_cb, 10)
+
+        self.get_logger().info('Waiting for action servers...')
+        # Essential — all in robot 2's own namespace, started by `just launch2`. Block until available.
+        self.cart_ac.wait_for_server()
+        self.joints_ac.wait_for_server()
+        self.onrobot_ac.wait_for_server()
+        self.conveyor_ac.wait_for_server()
+        # Optional — camera node is only started by `just launch1` / `just launch`. Warn and continue
+        # so rotate-only tests work with just `launch2`.
+        if not self.capture_client.wait_for_service(timeout_sec=5.0):
+            self.get_logger().warn('Camera capture service /mv_camera/capture not available after 5 s — continuing.')
+        self.get_logger().info(f'Robot 2 ready — namespace: /{ns}')
+
+    # ── Coordination ──────────────────────────────────────────────────────────
+
+    def _r1_location_cb(self, msg: String):
+        self.robot1_location = msg.data
+
+    def _publish_location(self, state: str):
+        msg = String()
+        msg.data = state
+        self.r2_location_pub.publish(msg)
+        self.get_logger().info(f'robot2_dice_location: {state}')
+
+    def _wait_for_robot1(self, *states: str):
+        """Wait until robot1_location matches any given state. Returns the matched state."""
+        label = ' or '.join(states)
+        self.get_logger().info(f'Waiting for robot1_dice_location: {label}')
+        while rclpy.ok():
+            rclpy.spin_once(self, timeout_sec=0.1)
+            if self.robot1_location in states:
+                return self.robot1_location
+
+    def _r1_flip_log_cb(self, msg: String):
+        try:
+            self.robot1_flip_log = json.loads(msg.data)
+        except json.JSONDecodeError:
+            self.get_logger().warn(f'Could not parse robot1 flip_log: {msg.data}')
+
+    def _publish_flip_log(self):
+        msg = String()
+        msg.data = json.dumps({str(k): v for k, v in self.flip_log.items()})
+        self.flip_log_pub.publish(msg)
+
+    def _publish_done_state(self, target_pip):
+        state = 'run_complete' if target_pip == 6 else 'on_conveyer'
+        self._publish_location(state)
+
+    def _print_summary(self):
+        own_total   = sum(self.flip_log.values())
+        other       = {int(k): v for k, v in self.robot1_flip_log.items()}
+        other_total = sum(other.values())
+        lines = ['═══ Robot 1 flip summary ═══']
+        if other:
+            for pip in sorted(other):
+                lines.append(f'  pip {pip}: {other[pip]} flip(s)')
+            lines.append(f'  Robot 1 total: {other_total}')
+        else:
+            lines.append('  (Robot 1 flip log not received)')
+        lines.append('═══ Robot 2 flip summary ═══')
+        for pip in sorted(self.flip_log):
+            lines.append(f'  pip {pip}: {self.flip_log[pip]} flip(s)')
+        lines.append(f'  Robot 2 total: {own_total}')
+        lines.append(f'═══ Combined total: {own_total + other_total} ═══')
+        for line in lines:
+            self.get_logger().info(line)
+
+    # ── Camera ────────────────────────────────────────────────────────────────
+
+    def _image_cb(self, msg):
+        self.latest_image = self.bridge.imgmsg_to_cv2(msg, desired_encoding='bgr8')
+
+    def _capture_image(self):
+        self.latest_image = None
+        future = self.capture_client.call_async(Trigger.Request())
+        rclpy.spin_until_future_complete(self, future)
+        if not future.result().success:
+            self.get_logger().error('Camera capture service returned failure.')
+            return None
+        deadline_ns = self.get_clock().now().nanoseconds + int(3.0 * 1e9)
+        while self.latest_image is None:
+            rclpy.spin_once(self, timeout_sec=0.05)
+            if self.get_clock().now().nanoseconds > deadline_ns:
+                self.get_logger().error('Timed out waiting for camera frame.')
+                return None
+        return self.latest_image.copy()
+
+    def _crop_die(self, image):
+        image = image[ROI_Y1:ROI_Y2, ROI_X1:ROI_X2]   # narrow search to ROI
+        hsv  = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
+        mask = cv2.inRange(hsv,
+                           np.array([HSV_H_LOW,  HSV_S_LOW,  HSV_V_LOW]),
+                           np.array([HSV_H_HIGH, HSV_S_HIGH, HSV_V_HIGH]))
+        kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (5, 5))
+        mask   = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel)
+        mask   = cv2.morphologyEx(mask, cv2.MORPH_OPEN,  kernel)
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        contours = [c for c in contours if cv2.contourArea(c) >= MIN_CONTOUR_AREA]
+        if not contours:
+            self.get_logger().warn('HSV crop: no region above MIN_CONTOUR_AREA — using full image.')
+            return image
+        # Match calibrate-hsv exactly: fill the chosen contour, bitwise_and with the
+        # ROI so everything outside the die contour goes black, then crop.
+        c = max(contours, key=cv2.contourArea)
+        die_mask = np.zeros(image.shape[:2], dtype=np.uint8)
+        cv2.drawContours(die_mask, [c], -1, 255, thickness=cv2.FILLED)
+        masked = cv2.bitwise_and(image, image, mask=die_mask)
+        x, y, w, h = cv2.boundingRect(c)
+        pad = 10
+        return masked[max(0, y-pad):min(image.shape[0], y+h+pad),
+                      max(0, x-pad):min(image.shape[1], x+w+pad)]
+
+    def _count_pips(self, image):
+        gray    = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        blurred = cv2.GaussianBlur(gray, (11, 11), 2)
+        circles = cv2.HoughCircles(blurred, cv2.HOUGH_GRADIENT,
+                                   dp=HOUGH_DP, minDist=HOUGH_MIN_DIST,
+                                   param1=HOUGH_PARAM1, param2=HOUGH_PARAM2,
+                                   minRadius=HOUGH_MIN_R, maxRadius=HOUGH_MAX_R)
+        debug = image.copy()
+        if circles is None:
+            cv2.putText(debug, 'No pips detected', (20, 40),
+                        cv2.FONT_HERSHEY_SIMPLEX, 1.0, (0, 0, 255), 2)
+            return 0, debug
+        for (cx, cy, r) in np.round(circles[0]).astype(int):
+            cv2.circle(debug, (cx, cy), r, (0, 255, 0), 2)
+            cv2.circle(debug, (cx, cy), 3, (0, 0, 255), -1)
+        count = len(circles[0])
+        cv2.putText(debug, f'Pips: {count}', (20, 40),
+                    cv2.FONT_HERSHEY_SIMPLEX, 1.0, (0, 255, 0), 2)
+        return count, debug
+
+    def _capture_face(self, die_x, die_y, die_z, label='Face'):
+        """Capture image, count pips, save debug images. Returns (count, debug).
+        Returns (None, None) on camera failure; count may be 0 if no pips detected."""
+        image = self._capture_image()
+        if image is None:
+            self.get_logger().error(f'{label}: camera did not return a frame.')
+            return None, None
+        slug = label.lower().replace(' ', '_')
+        cv2.imwrite(f'{IMAGE_SAVE_DIR}r2_{slug}_full.png', image)
+        cropped = self._crop_die(image)
+        count, debug = self._count_pips(cropped)
+        cv2.imwrite(f'{IMAGE_SAVE_DIR}r2_{slug}.png', debug)
+        self.get_logger().info(f'Expected Pip: {self.target_pip} ---- Saw Pip: {count}')
+        return count, debug
+
+    def _is_valid_pip(self, count, label):
+        """Return True if count is a valid die face (1–6); log a clear error otherwise."""
+        if count is None:
+            self.get_logger().error(
+                f'{label}: camera failure — cannot read pip count. Aborting.')
+            return False
+        if count not in VALID_PIP_COUNTS:
+            self.get_logger().error(
+                f'{label}: invalid pip count {count} (must be 1–6). '
+                f'Check camera, lighting, or Hough calibration. Aborting.')
+            return False
+        return True
+
+    # ── Motion primitives ─────────────────────────────────────────────────────
+
+    def _send_goal(self, client, goal):
+        future = client.send_goal_async(goal)
+        rclpy.spin_until_future_complete(self, future)
+        gh = future.result()
+        if not gh.accepted:
+            self.get_logger().error('Goal rejected.')
+            return None
+        rf = gh.get_result_async()
+        rclpy.spin_until_future_complete(self, rf)
+        return rf.result().result
+
+    def _move_cart(self, x, y, z, w=200.0, p=200.0, r=200.0):
+        goal = CartPose.Goal()
+        goal.x, goal.y, goal.z = float(x), float(y), float(z)
+        goal.w, goal.p, goal.r = float(w), float(p), float(r)
+        res = self._send_goal(self.cart_ac, goal)
+        return res is not None and res.success
+
+    def _move_joints(self, j1, j2, j3, j4, j5, j6):
+        goal = JointPose.Goal()
+        goal.joint1, goal.joint2, goal.joint3 = float(j1), float(j2), float(j3)
+        goal.joint4, goal.joint5, goal.joint6 = float(j4), float(j5), float(j6)
+        res = self._send_goal(self.joints_ac, goal)
+        return res is not None and res.success
+
+    def _onrobot(self, command, width=None, delay=3.0):
+        # Resolve the actual width that would be commanded.
+        if width is not None:
+            target_width = width
+        elif command == 'open':
+            target_width = ONROBOT_OPEN_WIDTH
+        else:
+            target_width = ONROBOT_CLOSE_WIDTH
+
+        # Skip if the gripper is already at the same width — saves the 3 s settle time.
+        if self.last_gripper_width == target_width:
+            self.get_logger().info(
+                f'Gripper already at width {target_width} — skipping {command}.')
+            return True
+
+        goal = OnRobotGripper.Goal()
+        goal.width = target_width
+        goal.force = ONROBOT_FORCE
+        res = self._send_goal(self.onrobot_ac, goal)
+        time.sleep(delay)
+        ok = res is not None and res.success
+        if ok:
+            self.last_gripper_width = target_width
+        return ok
+
+    def _conveyor(self, command):
+        goal = Conveyor.Goal()
+        goal.command = command
+        res = self._send_goal(self.conveyor_ac, goal)
+        return res is not None and res.success
+
+    def _set_speed(self, speed=ROBOT_SPEED):
+        if not self.speed_client.wait_for_service(timeout_sec=3.0):
+            self.get_logger().warn('set_speed service not available.')
+            return
+        req = SetSpeed.Request()
+        req.speed = speed
+        future = self.speed_client.call_async(req)
+        rclpy.spin_until_future_complete(self, future)
+
+    def go_home(self):
+        self.get_logger().info('Going home...')
+        self._move_joints(*HOME_JOINTS)
+        self._onrobot('open')
+
+    def _pick_from_dice_end(self):
+        """Pick die from DICE_END, place at DICE_PLACE, retreat for camera."""
+        pk = DICE_END
+        pl = DICE_PLACE
+
+        self._onrobot('open')
+        self._move_cart(pk['x'], pk['y'], pk['z'] + 2*DICE_WIDTH, pk['w'], pk['p'], pk['r'])  # hover
+        self._move_cart(pk['x'], pk['y'], pk['z'],                pk['w'], pk['p'], pk['r'])  # descend
+        self._onrobot('close')
+        self._move_cart(pk['x'], pk['y'], pk['z'] + 2*DICE_WIDTH, pk['w'], pk['p'], pk['r'])  # lift straight up to safe z
+        self._move_cart(pl['x'], pl['y'], pl['z'] + 2*DICE_WIDTH, pl['w'], pl['p'], pl['r'])  # transit horizontally at safe z
+        self._move_cart(pl['x'], pl['y'], pl['z'],                pl['w'], pl['p'], pl['r'])  # lower to place
+        self._onrobot('open')
+        self._move_cart(pl['x'], pl['y'], pl['z'] + 2*DICE_WIDTH,   pl['w'], pl['p'], pl['r'])  # retreat
+
+    # ── Flip primitives ───────────────────────────────────────────────────────
+
+    def _rotate_x_neg_90(self):
+        """−90° about x: grab from current die position, transit to FLIP_X_GRAB, release, retreat +y.
+        Counts as one physical flip; wrappers (flip_x_180, rotate_x_pos_90, y rotates) compose."""
+        self.flip_count += 1
+        dp = DICE_PLACE
+        fg = FLIP_X_GRAB
+        dw, dpw, dr = dp['w'], dp['p'], dp['r']
+
+        self._move_cart(dp['x'], dp['y'], dp['z'] + 2*DICE_WIDTH, dw, dpw, dr)              # hover above die
+        self._onrobot('open')
+        self._move_cart(dp['x'], dp['y'], dp['z'],              dw, dpw, dr)                 # lower to grab
+        self._onrobot('close', width=80)
+        self._move_cart(dp['x'], dp['y'], dp['z'] + DICE_WIDTH, dw, dpw, dr)                # lift
+        self._move_cart(fg['x'], fg['y'], fg['z'] + DICE_WIDTH, fg['w'], fg['p'], fg['r'])  # transit + rotate wrist
+        self._move_cart(fg['x'], fg['y'], fg['z'],              fg['w'], fg['p'], fg['r'])  # lower to flip position
+        self._onrobot('open')
+        self._move_cart(fg['x'], fg['y'] + DICE_WIDTH, fg['z'], fg['w'], fg['p'], fg['r'])  # retreat +y
+
+    def _rotate_x_pos_90(self):
+        """+90° about x via three consecutive −90° rotations. Pure motion (no scan)."""
+        self._rotate_x_neg_90()
+        self._rotate_x_neg_90()
+        self._rotate_x_neg_90()
+
+
+    def _rotate_x_neg_90_and_scan(self, label='flip'):
+        """−90° about x, then capture and return pip count. Returns None and aborts on bad read."""
+        self._rotate_x_neg_90()
+        fg = FLIP_X_GRAB
+        count, _ = self._capture_face(fg['x'], fg['y'], fg['z'], label)
+        if not self._is_valid_pip(count, label):
+            return None
+        return count
+
+    def _rotate_y_neg_90(self):
+        """Rotate die −90° about y: J6 −90° at current die position, set down, then single _rotate_x_neg_90.
+        With DICE_PLACE['r'] = -90, dr_rot = -180 wraps to +180 then clamps to +179.9 to stay inside J6 limits;
+        the controller takes the shorter J6 −90° path to reach the wrapped target."""
+        dp = DICE_PLACE
+        dw, dpw, dr = dp['w'], dp['p'], dp['r']
+        dr_rot = dr - 90
+        if dr_rot <= -180:
+            dr_rot += 360  # wrap to equivalent +angle inside ±180
+        dr_rot = max(min(dr_rot, 179.9), -179.9)  # stay inside J6 ±179.9° limit
+
+        self._move_cart(dp['x'], dp['y'], dp['z'] + 2*DICE_WIDTH, dw, dpw, dr)          # hover
+        self._onrobot('open')
+        self._move_cart(dp['x'], dp['y'], dp['z'],              dw, dpw, dr)             # lower to grab
+        self._onrobot('close', width=80)
+        self._move_cart(dp['x'], dp['y'], dp['z'] + DICE_WIDTH, dw, dpw, dr)            # lift
+        self._move_cart(dp['x'], dp['y'], dp['z'] + DICE_WIDTH, dw, dpw, dr_rot)        # J6 −90° (yaw die)
+        self._move_cart(dp['x'], dp['y'], dp['z'],              dw, dpw, dr_rot)         # lower with new orientation
+        self._onrobot('open')
+        self._move_cart(dp['x'], dp['y'], dp['z'] + DICE_WIDTH, dw, dpw, dr_rot)        # lift
+        self._move_cart(dp['x'], dp['y'], dp['z'] + 2*DICE_WIDTH, dw, dpw, dr)          # J6 +90° (back to standard)
+        self._rotate_x_neg_90()
+
+    def _rotate_y_pos_90(self):
+        """Rotate die +90° about y: J6 +90° at current die position, set down, then single _rotate_x_neg_90.
+        With DICE_PLACE['r'] = -90, dr_rot = 0 — no wrap needed; clamp is a no-op for this robot."""
+        dp = DICE_PLACE
+        dw, dpw, dr = dp['w'], dp['p'], dp['r']
+        dr_rot = dr + 90
+        if dr_rot >= 180:
+            dr_rot -= 360  # wrap to equivalent −angle inside ±180
+        dr_rot = max(min(dr_rot, 179.9), -179.9)  # stay inside J6 ±179.9° limit
+
+        self._move_cart(dp['x'], dp['y'], dp['z'] + 2*DICE_WIDTH, dw, dpw, dr)          # hover
+        self._onrobot('open')
+        self._move_cart(dp['x'], dp['y'], dp['z'],              dw, dpw, dr)             # lower to grab
+        self._onrobot('close', width=80)
+        self._move_cart(dp['x'], dp['y'], dp['z'] + DICE_WIDTH, dw, dpw, dr)            # lift
+        self._move_cart(dp['x'], dp['y'], dp['z'] + DICE_WIDTH, dw, dpw, dr_rot)        # J6 +90° (yaw die)
+        self._move_cart(dp['x'], dp['y'], dp['z'],              dw, dpw, dr_rot)         # lower with new orientation
+        self._onrobot('open')
+        self._move_cart(dp['x'], dp['y'], dp['z'] + DICE_WIDTH, dw, dpw, dr_rot)        # lift
+        self._move_cart(dp['x'], dp['y'], dp['z'] + 2*DICE_WIDTH, dw, dpw, dr)          # J6 −90° (back to standard)
+        self._rotate_x_neg_90()
+
+    def _flip_x_180(self):
+        """180° about x via two −90° rotations."""
+        self._rotate_x_neg_90()
+        self._rotate_x_neg_90()
+
+    
+    # ── Pip orientation ───────────────────────────────────────────────────────
+
+    def _orient_pip(self, target_pip, scan_top, scan_left):
+        """Look up (target_pip, scan_top, scan_left) and apply the rotation.
+        Verification happens in _scan_orient_place's pre-conveyor scan."""
+        action = get_action(target_pip, scan_top, scan_left)
+        if action is None:
+            self.get_logger().error(
+                f'Unrecognised orientation for pip {target_pip}: '
+                f'top={scan_top} left={scan_left}. '
+                f'Check detection accuracy or die chirality.')
+            return False
+        self.get_logger().info(
+            f'Pip {target_pip} — orientation ({scan_top},{scan_left}) → action: {action}')
+
+        if action == 'none':
+            pass
+        elif action == 'rotate_y_neg90':
+            self._rotate_y_neg_90()
+        elif action == 'rotate_y_pos90':
+            self._rotate_y_pos_90()
+        elif action == 'flip_x_180':
+            self._flip_x_180()
+        elif action == 'rotate_x_neg90':
+            self._rotate_x_neg_90()
+        elif action == 'rotate_x_pos90':
+            self._rotate_x_pos_90()
+        return True
+
+    # ── Placement ─────────────────────────────────────────────────────────────
+
+    def _place_on_front_conveyor(self):
+        """Pick die from current die position (top-down grip), transit to front conveyor, release."""
+        cp = CONVEYOR_PLACE_FRONT
+        dp = DICE_PLACE
+        pickup_hover_z = dp['z'] + 2 * DICE_WIDTH   # hover above die
+        safe_z         = cp['z'] + DICE_WIDTH        # clear height for transit
+
+        # ── Pick up die ───────────────────────────────────────────────────────
+        self._move_cart(dp['x'], dp['y'], pickup_hover_z, dp['w'], dp['p'], dp['r'])  # hover over die
+        self._onrobot('open')
+        self._move_cart(dp['x'], dp['y'], dp['z'],        dp['w'], dp['p'], dp['r'])  # descend to die
+        self._onrobot('close', width=80)
+        self._move_cart(dp['x'], dp['y'], safe_z,         dp['w'], dp['p'], dp['r'])  # lift to safe z
+
+        # ── Place on front conveyor ───────────────────────────────────────────
+        self._move_cart(cp['x'], cp['y'], safe_z,  cp['w'], cp['p'], cp['r'])  # transit
+        self._move_cart(cp['x'], cp['y'], cp['z'], cp['w'], cp['p'], cp['r'])  # lower to conveyor
+        self._onrobot('open')
+        self._move_cart(cp['x'], cp['y'], safe_z,  cp['w'], cp['p'], cp['r'])  # lift away
+
+    def _place_at_dice_end(self):
+        """Pick die from DICE_PLACE (top-down grip), transit to DICE_END, release. Used after pip 6."""
+        de = DICE_END
+        dp = DICE_PLACE
+        pickup_hover_z = dp['z'] + 2 * DICE_WIDTH
+        safe_z         = max(dp['z'], de['z']) + 2 * DICE_WIDTH  # clears both source and destination
+
+        # ── Pick up die ───────────────────────────────────────────────────────
+        self._move_cart(dp['x'], dp['y'], pickup_hover_z, dp['w'], dp['p'], dp['r'])  # hover
+        self._onrobot('open')
+        self._move_cart(dp['x'], dp['y'], dp['z'],        dp['w'], dp['p'], dp['r'])  # descend
+        self._onrobot('close', width=80)
+        self._move_cart(dp['x'], dp['y'], safe_z,         dp['w'], dp['p'], dp['r'])  # lift to safe z
+
+        # ── Place at DICE_END ─────────────────────────────────────────────────
+        self._move_cart(de['x'], de['y'], safe_z,  de['w'], de['p'], de['r'])  # transit
+        self._move_cart(de['x'], de['y'], de['z'], de['w'], de['p'], de['r'])  # lower to dice end
+        self._onrobot('open')
+        self._move_cart(de['x'], de['y'], safe_z,  de['w'], de['p'], de['r'])  # lift away
+
+    # ── Task sequence ─────────────────────────────────────────────────────────
+
+    def _scan_orient_place(self, target_pip=2):
+        """Scan die at DICE_PLACE, orient target_pip to top, place on front conveyor.
+        Called both from the full sequence (after conveyor pickup) and from test mode."""
+        self.target_pip = target_pip
+        self.flip_count = 0
+        dp = DICE_PLACE
+        hover_z = dp['z'] + 2 * DICE_WIDTH
+
+        # ── Scan 1: top face ──────────────────────────────────────────────────
+        self._move_cart(dp['x'], dp['y'] + 3*DICE_WIDTH, hover_z, dp['w'], dp['p'], dp['r'])  # retreat for photo
+        scan_top, _ = self._capture_face(dp['x'], dp['y'], dp['z'], 'top')
+        if not self._is_valid_pip(scan_top, 'Scan 1'):
+            return False
+
+        if scan_top == target_pip:
+            self.get_logger().info(f'Pip {target_pip} already on top — skipping flip and scan 2.')
+            if target_pip == 6:
+                self._place_at_dice_end()
+            else:
+                self._place_on_front_conveyor()
+            self.flip_log[target_pip] = self.flip_count
+            self._publish_flip_log()
+            self._publish_done_state(target_pip)
+            return True
+
+        self._move_cart(dp['x'], dp['y'], hover_z, dp['w'], dp['p'], dp['r'])  # goto hover
+
+        # ── X-flip to expose adjacent face ───────────────────────────────────
+        self._rotate_x_neg_90()
+
+        # ── Scan 2: left/adjacent face (now on top after flip) ────────────────
+        fg = FLIP_X_GRAB
+        scan_left, _ = self._capture_face(fg['x'], fg['y'], fg['z'], 'left')
+        if not self._is_valid_pip(scan_left, 'Scan 2'):
+            return False
+
+        # ── Orient target pip on top (camera-verified) ────────────────────────
+        if not self._orient_pip(target_pip, scan_top, scan_left):
+            self.get_logger().error(f'Cannot orient pip {target_pip} — aborting cycle.')
+            return False
+
+        # ── Pre-conveyor verification scan ────────────────────────────────────
+        verify_count, _ = self._capture_face(dp['x'], dp['y'], dp['z'], 'verify_top')
+        if verify_count != target_pip:
+            self.get_logger().error(
+                f'Pre-conveyor verification FAILED — expected pip {target_pip} on top, '
+                f'camera sees {verify_count}. Aborting placement.')
+            return False
+        self.get_logger().info(f'Pre-conveyor verification: pip {target_pip} confirmed on top.')
+
+        # ── Pick up and place ─────────────────────────────────────────────────
+        if target_pip == 6:
+            self._place_at_dice_end()
+        else:
+            self._place_on_front_conveyor()
+        self.flip_log[target_pip] = self.flip_count
+        self._publish_flip_log()
+        self._publish_done_state(target_pip)
+        return True
+
+    def _execute_sequence(self, target_pip):
+        self._publish_location('rotating')
+
+        # ── Conveyor pickup ───────────────────────────────────────────────────
+        hs = CONVEYOR_HARD_STOP
+        self.get_logger().info('Moving to conveyor hard stop...')
+        self._move_cart(hs['x'], hs['y'], hs['z'], hs['w'], hs['p'], hs['r'])
+        self._onrobot('close')
+
+        self._publish_location('at_back_conveyer')
+        self._wait_for_robot1('conveyer_done')
+        self.get_logger().info('Conveyor done — grabbing die.')
+
+        cp = CONVEYOR_PICK
+        self._onrobot('open', delay=3.0)
+        self._move_cart(cp['x'], cp['y'], cp['z'], cp['w'], cp['p'], cp['r'])
+        self._onrobot('close', width=80)
+
+        hover_z = cp['z'] + 2 * DICE_WIDTH
+        self._move_cart(cp['x'], cp['y'], hover_z, cp['w'], cp['p'], cp['r'])
+
+        # ── Transport to DICE_PLACE ───────────────────────────────────────────
+        dp = DICE_PLACE
+        self._move_cart(dp['x'], dp['y'], hover_z, dp['w'], dp['p'], dp['r'])  # transit at height
+        self._move_cart(dp['x'], dp['y'], dp['z'],  dp['w'], dp['p'], dp['r'])  # lower
+        self._onrobot('open')
+
+        self._scan_orient_place(target_pip)
+
+        if target_pip == 6:
+            return  # End of run — robot 1 won't pick up; main loop will home + exit
+
+        # ── Wait for Robot 1 at front conveyor, then run it ──────────────────
+        self.robot1_location = ''
+        self.get_logger().info('Waiting for Robot 1 at front conveyor hard stop...')
+        self._wait_for_robot1('at_front_conveyer')
+        self.robot1_location = ''
+        self.get_logger().info('Robot 1 in position — running front conveyor 10 seconds...')
+        self._conveyor('reverse')
+        import time; time.sleep(10)
+        self._conveyor('stop')
+        self._publish_location('front_conveyer_done')
+
+        # ── Return to hard stop — pre-positioned for next pickup ─────────────
+        hs = CONVEYOR_HARD_STOP
+        self.get_logger().info('Returning to hard stop — ready for next cycle.')
+        self._move_cart(hs['x'], hs['y'], hs['z'], hs['w'], hs['p'], hs['r'])
+        self._onrobot('close')
+
+    # ── Main loop ─────────────────────────────────────────────────────────────
+
+    def run(self):
+        self._set_speed()
+        self.go_home()
+
+        for target_pip in (2, 4, 6):
+            self.get_logger().info(f'Waiting for Robot 1 — pip {target_pip} cycle...')
+            self._wait_for_robot1('on_conveyer')
+            self.robot1_location = ''
+            self._execute_sequence(target_pip)
+
+        # ── Run complete (pip 6 placed) — print summary, return home, exit ────
+        self._print_summary()
+        self.go_home()
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = Robot2Node()
+    node.run()
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+def main_rotate(args=None):
+    """Assume die is already at DICE_PLACE; run all five rotation primitives."""
+    rclpy.init(args=args)
+    node = Robot2Node()
+    node._set_speed()
+
+    node.go_home()
+
+    de = DICE_PLACE
+    node._move_cart(de['x'], de['y'], de['z'], de['w'], de['p'], de['r'])  # lower to dice end
+
+    node.get_logger().info('Rotating about x positive 90 degrees')
+    node._rotate_x_pos_90()
+
+    node.get_logger().info('Rotating about x negative 90 degrees')
+    node._rotate_x_neg_90()
+
+    node.get_logger().info('Rotating about y negative 90 degrees')
+    node._rotate_y_neg_90()
+
+    node.get_logger().info('Rotating about y positive 90 degrees')
+    node._rotate_y_pos_90()
+
+    node.get_logger().info('Flipping about x 180 degrees')
+    node._flip_x_180()
+
+    
+
+    node.go_home()
+    node.get_logger().info('--- Rotate test complete ---')
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/dual_fanuc/launch/dual_fanuc.launch.py
+++ b/src/dual_fanuc/launch/dual_fanuc.launch.py
@@ -1,0 +1,13 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package='dual_fanuc',
+            executable='mv_camera_node',
+            name='mv_camera_node',
+            output='screen',
+        ),
+    ])

--- a/src/dual_fanuc/package.xml
+++ b/src/dual_fanuc/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>dual_fanuc</name>
+  <version>0.1.0</version>
+  <description>Dual-robot FANUC dice assignment — robot 1 picks and presents dice, robot 2 responds to pip count</description>
+  <maintainer email="maintainer@example.com">Maintainer</maintainer>
+  <license>GPL-3.0</license>
+
+  <depend>fanuc_interfaces</depend>
+  <depend>rclpy</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_srvs</depend>
+  <depend>cv_bridge</depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/src/dual_fanuc/setup.cfg
+++ b/src/dual_fanuc/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/dual_fanuc
+[install]
+install_scripts=$base/lib/dual_fanuc

--- a/src/dual_fanuc/setup.py
+++ b/src/dual_fanuc/setup.py
@@ -1,0 +1,33 @@
+import os
+from glob import glob
+from setuptools import find_packages, setup
+
+package_name = 'dual_fanuc'
+
+setup(
+    name=package_name,
+    version='0.1.0',
+    packages=[package_name],
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+        (os.path.join('share', package_name, 'launch'),
+            glob(os.path.join('launch', '*launch.[pxy][yma]*'))),
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    maintainer='Maintainer',
+    maintainer_email='maintainer@example.com',
+    description='Dual-robot FANUC dice assignment',
+    license='GPL-3.0',
+    entry_points={
+        'console_scripts': [
+            'robot1         = dual_fanuc.robot1:main',
+            'robot2         = dual_fanuc.robot2:main',
+            'mv_camera_node = dual_fanuc.mv_camera_node:main',
+            'rotate1        = dual_fanuc.robot1:main_rotate',
+            'rotate2        = dual_fanuc.robot2:main_rotate',
+        ],
+    },
+)

--- a/third_party/mvsdk.py
+++ b/third_party/mvsdk.py
@@ -1,0 +1,2435 @@
+#coding=utf-8
+import platform
+from ctypes import *
+from threading import local
+
+# 回调函数类型
+CALLBACK_FUNC_TYPE = None
+
+# SDK动态库
+_sdk = None
+
+def _Init():
+	global _sdk
+	global CALLBACK_FUNC_TYPE
+
+	is_win = (platform.system() == "Windows")
+	is_x86 = (platform.architecture()[0] == '32bit')
+
+	if is_win:
+		_sdk = windll.MVCAMSDK if is_x86 else windll.MVCAMSDK_X64
+		CALLBACK_FUNC_TYPE = WINFUNCTYPE
+	else:
+		_sdk = cdll.LoadLibrary("libMVSDK.so")
+		CALLBACK_FUNC_TYPE = CFUNCTYPE
+
+_Init()
+
+#-------------------------------------------类型定义--------------------------------------------------
+
+# 状态码定义
+CAMERA_STATUS_SUCCESS = 0   # 操作成功
+CAMERA_STATUS_FAILED = -1   # 操作失败
+CAMERA_STATUS_INTERNAL_ERROR = -2   # 内部错误
+CAMERA_STATUS_UNKNOW = -3   # 未知错误
+CAMERA_STATUS_NOT_SUPPORTED = -4   # 不支持该功能
+CAMERA_STATUS_NOT_INITIALIZED = -5   # 初始化未完成
+CAMERA_STATUS_PARAMETER_INVALID = -6   # 参数无效
+CAMERA_STATUS_PARAMETER_OUT_OF_BOUND = -7   # 参数越界
+CAMERA_STATUS_UNENABLED = -8   # 未使能
+CAMERA_STATUS_USER_CANCEL = -9   # 用户手动取消了，比如roi面板点击取消，返回
+CAMERA_STATUS_PATH_NOT_FOUND = -10  # 注册表中没有找到对应的路径
+CAMERA_STATUS_SIZE_DISMATCH = -11  # 获得图像数据长度和定义的尺寸不匹配
+CAMERA_STATUS_TIME_OUT = -12  # 超时错误
+CAMERA_STATUS_IO_ERROR = -13  # 硬件IO错误
+CAMERA_STATUS_COMM_ERROR = -14  # 通讯错误
+CAMERA_STATUS_BUS_ERROR = -15  # 总线错误
+CAMERA_STATUS_NO_DEVICE_FOUND = -16  # 没有发现设备
+CAMERA_STATUS_NO_LOGIC_DEVICE_FOUND = -17  # 未找到逻辑设备
+CAMERA_STATUS_DEVICE_IS_OPENED = -18  # 设备已经打开
+CAMERA_STATUS_DEVICE_IS_CLOSED = -19  # 设备已经关闭
+CAMERA_STATUS_DEVICE_VEDIO_CLOSED = -20  # 没有打开设备视频，调用录像相关的函数时，如果相机视频没有打开，则回返回该错误。
+CAMERA_STATUS_NO_MEMORY = -21  # 没有足够系统内存
+CAMERA_STATUS_FILE_CREATE_FAILED = -22  # 创建文件失败
+CAMERA_STATUS_FILE_INVALID = -23  # 文件格式无效
+CAMERA_STATUS_WRITE_PROTECTED = -24  # 写保护，不可写
+CAMERA_STATUS_GRAB_FAILED = -25  # 数据采集失败
+CAMERA_STATUS_LOST_DATA = -26  # 数据丢失，不完整
+CAMERA_STATUS_EOF_ERROR = -27  # 未接收到帧结束符
+CAMERA_STATUS_BUSY = -28  # 正忙(上一次操作还在进行中)，此次操作不能进行
+CAMERA_STATUS_WAIT = -29  # 需要等待(进行操作的条件不成立)，可以再次尝试
+CAMERA_STATUS_IN_PROCESS = -30  # 正在进行，已经被操作过
+CAMERA_STATUS_IIC_ERROR = -31  # IIC传输错误
+CAMERA_STATUS_SPI_ERROR = -32  # SPI传输错误
+CAMERA_STATUS_USB_CONTROL_ERROR = -33  # USB控制传输错误
+CAMERA_STATUS_USB_BULK_ERROR = -34  # USB BULK传输错误
+CAMERA_STATUS_SOCKET_INIT_ERROR = -35  # 网络传输套件初始化失败
+CAMERA_STATUS_GIGE_FILTER_INIT_ERROR = -36  # 网络相机内核过滤驱动初始化失败，请检查是否正确安装了驱动，或者重新安装。
+CAMERA_STATUS_NET_SEND_ERROR = -37  # 网络数据发送错误
+CAMERA_STATUS_DEVICE_LOST = -38  # 与网络相机失去连接，心跳检测超时
+CAMERA_STATUS_DATA_RECV_LESS = -39  # 接收到的字节数比请求的少 
+CAMERA_STATUS_FUNCTION_LOAD_FAILED = -40  # 从文件中加载程序失败
+CAMERA_STATUS_CRITICAL_FILE_LOST = -41  # 程序运行所必须的文件丢失。
+CAMERA_STATUS_SENSOR_ID_DISMATCH = -42  # 固件和程序不匹配，原因是下载了错误的固件。
+CAMERA_STATUS_OUT_OF_RANGE = -43  # 参数超出有效范围。   
+CAMERA_STATUS_REGISTRY_ERROR = -44  # 安装程序注册错误。请重新安装程序，或者运行安装目录Setup/Installer.exe
+CAMERA_STATUS_ACCESS_DENY = -45  # 禁止访问。指定相机已经被其他程序占用时，再申请访问该相机，会返回该状态。(一个相机不能被多个程序同时访问) 
+#AIA的标准兼容的错误码
+CAMERA_AIA_PACKET_RESEND = 0x0100 #该帧需要重传
+CAMERA_AIA_NOT_IMPLEMENTED = 0x8001 #设备不支持的命令
+CAMERA_AIA_INVALID_PARAMETER = 0x8002 #命令参数非法
+CAMERA_AIA_INVALID_ADDRESS = 0x8003 #不可访问的地址
+CAMERA_AIA_WRITE_PROTECT = 0x8004 #访问的对象不可写
+CAMERA_AIA_BAD_ALIGNMENT = 0x8005 #访问的地址没有按照要求对齐
+CAMERA_AIA_ACCESS_DENIED = 0x8006 #没有访问权限
+CAMERA_AIA_BUSY = 0x8007 #命令正在处理中
+CAMERA_AIA_DEPRECATED = 0x8008 #0x8008-0x0800B  0x800F  该指令已经废弃
+CAMERA_AIA_PACKET_UNAVAILABLE = 0x800C #包无效
+CAMERA_AIA_DATA_OVERRUN = 0x800D #数据溢出，通常是收到的数据比需要的多
+CAMERA_AIA_INVALID_HEADER = 0x800E #数据包头部中某些区域与协议不匹配
+CAMERA_AIA_PACKET_NOT_YET_AVAILABLE = 0x8010 #图像分包数据还未准备好，多用于触发模式，应用程序访问超时
+CAMERA_AIA_PACKET_AND_PREV_REMOVED_FROM_MEMORY = 0x8011 #需要访问的分包已经不存在。多用于重传时数据已经不在缓冲区中
+CAMERA_AIA_PACKET_REMOVED_FROM_MEMORY = 0x8012 #CAMERA_AIA_PACKET_AND_PREV_REMOVED_FROM_MEMORY
+CAMERA_AIA_NO_REF_TIME = 0x0813 #没有参考时钟源。多用于时间同步的命令执行时
+CAMERA_AIA_PACKET_TEMPORARILY_UNAVAILABLE = 0x0814 #由于信道带宽问题，当前分包暂时不可用，需稍后进行访问
+CAMERA_AIA_OVERFLOW = 0x0815 #设备端数据溢出，通常是队列已满
+CAMERA_AIA_ACTION_LATE = 0x0816 #命令执行已经超过有效的指定时间
+CAMERA_AIA_ERROR = 0x8FFF   #错误
+
+# 图像格式定义
+CAMERA_MEDIA_TYPE_MONO = 0x01000000
+CAMERA_MEDIA_TYPE_RGB = 0x02000000
+CAMERA_MEDIA_TYPE_COLOR = 0x02000000
+CAMERA_MEDIA_TYPE_OCCUPY1BIT = 0x00010000
+CAMERA_MEDIA_TYPE_OCCUPY2BIT = 0x00020000
+CAMERA_MEDIA_TYPE_OCCUPY4BIT = 0x00040000
+CAMERA_MEDIA_TYPE_OCCUPY8BIT = 0x00080000
+CAMERA_MEDIA_TYPE_OCCUPY10BIT = 0x000A0000
+CAMERA_MEDIA_TYPE_OCCUPY12BIT = 0x000C0000
+CAMERA_MEDIA_TYPE_OCCUPY16BIT = 0x00100000
+CAMERA_MEDIA_TYPE_OCCUPY24BIT = 0x00180000
+CAMERA_MEDIA_TYPE_OCCUPY32BIT = 0x00200000
+CAMERA_MEDIA_TYPE_OCCUPY36BIT = 0x00240000
+CAMERA_MEDIA_TYPE_OCCUPY48BIT = 0x00300000
+CAMERA_MEDIA_TYPE_EFFECTIVE_PIXEL_SIZE_MASK = 0x00FF0000
+CAMERA_MEDIA_TYPE_EFFECTIVE_PIXEL_SIZE_SHIFT = 16
+CAMERA_MEDIA_TYPE_ID_MASK = 0x0000FFFF
+CAMERA_MEDIA_TYPE_COUNT = 0x46
+
+#mono
+CAMERA_MEDIA_TYPE_MONO1P = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY1BIT | 0x0037)
+CAMERA_MEDIA_TYPE_MONO2P = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY2BIT | 0x0038)
+CAMERA_MEDIA_TYPE_MONO4P = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY4BIT | 0x0039)
+CAMERA_MEDIA_TYPE_MONO8 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY8BIT | 0x0001)
+CAMERA_MEDIA_TYPE_MONO8S = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY8BIT | 0x0002)
+CAMERA_MEDIA_TYPE_MONO10 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0003)
+CAMERA_MEDIA_TYPE_MONO10_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x0004)
+CAMERA_MEDIA_TYPE_MONO12 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0005)
+CAMERA_MEDIA_TYPE_MONO12_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x0006)
+CAMERA_MEDIA_TYPE_MONO14 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0025)
+CAMERA_MEDIA_TYPE_MONO16 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0007)
+
+# Bayer
+CAMERA_MEDIA_TYPE_BAYGR8 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY8BIT | 0x0008)
+CAMERA_MEDIA_TYPE_BAYRG8 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY8BIT | 0x0009)
+CAMERA_MEDIA_TYPE_BAYGB8 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY8BIT | 0x000A)
+CAMERA_MEDIA_TYPE_BAYBG8 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY8BIT | 0x000B)
+
+CAMERA_MEDIA_TYPE_BAYGR10_MIPI = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY10BIT | 0x0026)
+CAMERA_MEDIA_TYPE_BAYRG10_MIPI = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY10BIT | 0x0027)
+CAMERA_MEDIA_TYPE_BAYGB10_MIPI = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY10BIT | 0x0028)
+CAMERA_MEDIA_TYPE_BAYBG10_MIPI = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY10BIT | 0x0029)
+
+CAMERA_MEDIA_TYPE_BAYGR10 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x000C)
+CAMERA_MEDIA_TYPE_BAYRG10 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x000D)
+CAMERA_MEDIA_TYPE_BAYGB10 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x000E)
+CAMERA_MEDIA_TYPE_BAYBG10 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x000F)
+
+CAMERA_MEDIA_TYPE_BAYGR12 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0010)
+CAMERA_MEDIA_TYPE_BAYRG12 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0011)
+CAMERA_MEDIA_TYPE_BAYGB12 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0012)
+CAMERA_MEDIA_TYPE_BAYBG12 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0013)
+
+CAMERA_MEDIA_TYPE_BAYGR10_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x0026)
+CAMERA_MEDIA_TYPE_BAYRG10_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x0027)
+CAMERA_MEDIA_TYPE_BAYGB10_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x0028)
+CAMERA_MEDIA_TYPE_BAYBG10_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x0029)
+
+CAMERA_MEDIA_TYPE_BAYGR12_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x002A)
+CAMERA_MEDIA_TYPE_BAYRG12_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x002B)
+CAMERA_MEDIA_TYPE_BAYGB12_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x002C)
+CAMERA_MEDIA_TYPE_BAYBG12_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x002D)
+
+CAMERA_MEDIA_TYPE_BAYGR16 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x002E)
+CAMERA_MEDIA_TYPE_BAYRG16 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x002F)
+CAMERA_MEDIA_TYPE_BAYGB16 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0030)
+CAMERA_MEDIA_TYPE_BAYBG16 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0031)
+
+# RGB
+CAMERA_MEDIA_TYPE_RGB8 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY24BIT | 0x0014)
+CAMERA_MEDIA_TYPE_BGR8 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY24BIT | 0x0015)
+CAMERA_MEDIA_TYPE_RGBA8 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY32BIT | 0x0016)
+CAMERA_MEDIA_TYPE_BGRA8 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY32BIT | 0x0017)
+CAMERA_MEDIA_TYPE_RGB10 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY48BIT | 0x0018)
+CAMERA_MEDIA_TYPE_BGR10 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY48BIT | 0x0019)
+CAMERA_MEDIA_TYPE_RGB12 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY48BIT | 0x001A)
+CAMERA_MEDIA_TYPE_BGR12 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY48BIT | 0x001B)
+CAMERA_MEDIA_TYPE_RGB16 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY48BIT | 0x0033)
+CAMERA_MEDIA_TYPE_RGB10V1_PACKED = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY32BIT | 0x001C)
+CAMERA_MEDIA_TYPE_RGB10P32 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY32BIT | 0x001D)
+CAMERA_MEDIA_TYPE_RGB12V1_PACKED = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY36BIT | 0X0034)
+CAMERA_MEDIA_TYPE_RGB565P = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0035)
+CAMERA_MEDIA_TYPE_BGR565P = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0X0036)
+
+# YUV and YCbCr
+CAMERA_MEDIA_TYPE_YUV411_8_UYYVYY = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x001E)
+CAMERA_MEDIA_TYPE_YUV422_8_UYVY = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x001F)
+CAMERA_MEDIA_TYPE_YUV422_8 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0032)
+CAMERA_MEDIA_TYPE_YUV8_UYV = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY24BIT | 0x0020)
+CAMERA_MEDIA_TYPE_YCBCR8_CBYCR = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY24BIT | 0x003A)
+#CAMERA_MEDIA_TYPE_YCBCR422_8 : YYYYCbCrCbCr
+CAMERA_MEDIA_TYPE_YCBCR422_8 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x003B)
+CAMERA_MEDIA_TYPE_YCBCR422_8_CBYCRY = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0043)
+CAMERA_MEDIA_TYPE_YCBCR411_8_CBYYCRYY = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x003C)
+CAMERA_MEDIA_TYPE_YCBCR601_8_CBYCR = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY24BIT | 0x003D)
+CAMERA_MEDIA_TYPE_YCBCR601_422_8 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x003E)
+CAMERA_MEDIA_TYPE_YCBCR601_422_8_CBYCRY = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0044)
+CAMERA_MEDIA_TYPE_YCBCR601_411_8_CBYYCRYY = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x003F)
+CAMERA_MEDIA_TYPE_YCBCR709_8_CBYCR = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY24BIT | 0x0040)
+CAMERA_MEDIA_TYPE_YCBCR709_422_8 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0041)
+CAMERA_MEDIA_TYPE_YCBCR709_422_8_CBYCRY = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0045)
+CAMERA_MEDIA_TYPE_YCBCR709_411_8_CBYYCRYY = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x0042)
+
+# RGB Planar
+CAMERA_MEDIA_TYPE_RGB8_PLANAR = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY24BIT | 0x0021)
+CAMERA_MEDIA_TYPE_RGB10_PLANAR = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY48BIT | 0x0022)
+CAMERA_MEDIA_TYPE_RGB12_PLANAR = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY48BIT | 0x0023)
+CAMERA_MEDIA_TYPE_RGB16_PLANAR = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY48BIT | 0x0024)
+
+# 保存格式
+FILE_JPG = 1
+FILE_BMP = 2
+FILE_RAW = 4
+FILE_PNG = 8 
+FILE_BMP_8BIT = 16
+FILE_PNG_8BIT = 32
+FILE_RAW_16BIT = 64
+
+# 触发信号
+EXT_TRIG_LEADING_EDGE = 0
+EXT_TRIG_TRAILING_EDGE = 1
+EXT_TRIG_HIGH_LEVEL = 2
+EXT_TRIG_LOW_LEVEL = 3
+EXT_TRIG_DOUBLE_EDGE = 4
+
+# IO模式
+IOMODE_TRIG_INPUT = 0
+IOMODE_STROBE_OUTPUT = 1
+IOMODE_GP_INPUT = 2
+IOMODE_GP_OUTPUT = 3
+IOMODE_PWM_OUTPUT = 4
+
+
+# 相机操作异常信息
+class CameraException(Exception):
+	"""docstring for CameraException"""
+	def __init__(self, error_code):
+		super(CameraException, self).__init__()
+		self.error_code = error_code
+		self.message = CameraGetErrorString(error_code)
+
+	def __str__(self):
+		return 'error_code:{} message:{}'.format(self.error_code, self.message)
+
+class MvStructure(Structure):
+	def __str__(self):
+		strs = []
+		for field in self._fields_:
+			name = field[0]
+			value = getattr(self, name)
+			if isinstance(value, type(b'')):
+				value = _string_buffer_to_str(value)
+			strs.append("{}:{}".format(name, value))
+		return '\n'.join(strs)
+
+	def __repr__(self):
+		return self.__str__()
+
+	def clone(self):
+		obj = type(self)()
+		memmove(byref(obj), byref(self), sizeof(self))
+		return obj
+
+# 相机的设备信息，只读信息，请勿修改
+class tSdkCameraDevInfo(MvStructure):
+	_fields_ = [("acProductSeries", c_char * 32), #产品系列
+				("acProductName", c_char * 32), #产品名称
+				("acFriendlyName", c_char * 32), #产品昵称
+				("acLinkName", c_char * 32), #内核符号连接名，内部使用
+				("acDriverVersion", c_char * 32), #驱动版本
+				("acSensorType", c_char * 32), #sensor类型
+				("acPortType", c_char * 32), #接口类型
+				("acSn", c_char * 32), #产品唯一序列号
+				("uInstance", c_uint)] #该型号相机在该电脑上的实例索引号，用于区分同型号多相机
+
+	def GetProductSeries(self):
+		return _string_buffer_to_str(self.acProductSeries)
+	def GetProductName(self):
+		return _string_buffer_to_str(self.acProductName)
+	def GetFriendlyName(self):
+		return _string_buffer_to_str(self.acFriendlyName)
+	def GetLinkName(self):
+		return _string_buffer_to_str(self.acLinkName)
+	def GetDriverVersion(self):
+		return _string_buffer_to_str(self.acDriverVersion)
+	def GetSensorType(self):
+		return _string_buffer_to_str(self.acSensorType)
+	def GetPortType(self):
+		return _string_buffer_to_str(self.acPortType)
+	def GetSn(self):
+		return _string_buffer_to_str(self.acSn)
+
+# 相机的分辨率设定范围
+class tSdkResolutionRange(MvStructure):
+	_fields_ = [("iHeightMax", c_int), 	#图像最大高度
+				("iHeightMin", c_int), 	#图像最小高度
+				("iWidthMax", c_int), 	#图像最大宽度
+				("iWidthMin", c_int), 	#图像最小宽度
+				("uSkipModeMask", c_uint), 		#SKIP模式掩码，为0，表示不支持SKIP 。bit0为1,表示支持SKIP 2x2 bit1为1，表示支持SKIP 3x3....
+				("uBinSumModeMask", c_uint), 	#BIN(求和)模式掩码，为0，表示不支持BIN 。bit0为1,表示支持BIN 2x2 bit1为1，表示支持BIN 3x3....
+				("uBinAverageModeMask", c_uint),#BIN(求均值)模式掩码，为0，表示不支持BIN 。bit0为1,表示支持BIN 2x2 bit1为1，表示支持BIN 3x3....
+				("uResampleMask", c_uint)] 		#硬件重采样的掩码
+
+#相机的分辨率描述
+class tSdkImageResolution(MvStructure):
+	_fields_ = [
+		("iIndex", c_int),                # 索引号，[0,N]表示预设的分辨率(N 为预设分辨率的最大个数，一般不超过20),OXFF 表示自定义分辨率(ROI)
+		("acDescription", c_char * 32),   # 该分辨率的描述信息。仅预设分辨率时该信息有效。自定义分辨率可忽略该信息
+		("uBinSumMode", c_uint),          # BIN(求和)的模式,范围不能超过tSdkResolutionRange中uBinSumModeMask
+		("uBinAverageMode", c_uint),      # BIN(求均值)的模式,范围不能超过tSdkResolutionRange中uBinAverageModeMask
+		("uSkipMode", c_uint),            # 是否SKIP的尺寸，为0表示禁止SKIP模式，范围不能超过tSdkResolutionRange中uSkipModeMask
+		("uResampleMask", c_uint),        # 硬件重采样的掩码
+		("iHOffsetFOV", c_int),        # 采集视场相对于Sensor最大视场左上角的垂直偏移
+		("iVOffsetFOV", c_int),        # 采集视场相对于Sensor最大视场左上角的水平偏移
+		("iWidthFOV", c_int),          # 采集视场的宽度 
+		("iHeightFOV", c_int),         # 采集视场的高度
+		("iWidth", c_int),             # 相机最终输出的图像的宽度
+		("iHeight", c_int),            # 相机最终输出的图像的高度
+		("iWidthZoomHd", c_int),       # 硬件缩放的宽度,不需要进行此操作的分辨率，此变量设置为0.
+		("iHeightZoomHd", c_int),      # 硬件缩放的高度,不需要进行此操作的分辨率，此变量设置为0.
+		("iWidthZoomSw", c_int),       # 软件缩放的宽度,不需要进行此操作的分辨率，此变量设置为0.
+		("iHeightZoomSw", c_int),      # 软件缩放的高度,不需要进行此操作的分辨率，此变量设置为0.
+	]
+
+	def GetDescription(self):
+		return _string_buffer_to_str(self.acDescription)
+
+#相机白平衡模式描述信息
+class tSdkColorTemperatureDes(MvStructure):
+	_fields_ = [
+		("iIndex", c_int),				# 模式索引号
+		("acDescription", c_char * 32), # 描述信息
+	]
+
+	def GetDescription(self):
+		return _string_buffer_to_str(self.acDescription)
+
+#相机帧率描述信息
+class tSdkFrameSpeed(MvStructure):
+	_fields_ = [
+		("iIndex", c_int),				# 帧率索引号，一般0对应于低速模式，1对应于普通模式，2对应于高速模式      
+		("acDescription", c_char * 32), # 描述信息
+	]
+
+	def GetDescription(self):
+		return _string_buffer_to_str(self.acDescription)
+
+#相机曝光功能范围定义
+class tSdkExpose(MvStructure):
+	_fields_ = [
+		("uiTargetMin", c_uint),       #自动曝光亮度目标最小值
+		("uiTargetMax", c_uint),       #自动曝光亮度目标最大值
+		("uiAnalogGainMin", c_uint),   #模拟增益的最小值，单位为fAnalogGainStep中定义      
+		("uiAnalogGainMax", c_uint),   #模拟增益的最大值，单位为fAnalogGainStep中定义        
+		("fAnalogGainStep", c_float),  #模拟增益每增加1，对应的增加的放大倍数。例如，uiAnalogGainMin一般为16，fAnalogGainStep一般为0.125，那么最小放大倍数就是16*0.125 = 2倍
+		("uiExposeTimeMin", c_uint),   #手动模式下，曝光时间的最小值，单位:行。根据CameraGetExposureLineTime可以获得一行对应的时间(微秒),从而得到整帧的曝光时间    
+		("uiExposeTimeMax", c_uint),   #手动模式下，曝光时间的最大值，单位:行
+	]
+
+#触发模式描述
+class tSdkTrigger(MvStructure):
+	_fields_ = [
+		("iIndex", c_int),				# 模式索引号      
+		("acDescription", c_char * 32), # 描述信息
+	]
+
+	def GetDescription(self):
+		return _string_buffer_to_str(self.acDescription)
+
+#传输分包大小描述(主要是针对网络相机有效)
+class tSdkPackLength(MvStructure):
+	_fields_ = [
+		("iIndex", c_int),				# 模式索引号      
+		("acDescription", c_char * 32), # 描述信息
+		("iPackSize", c_uint),
+	]
+
+	def GetDescription(self):
+		return _string_buffer_to_str(self.acDescription)
+
+#预设的LUT表描述
+class tSdkPresetLut(MvStructure):
+	_fields_ = [
+		("iIndex", c_int),				# 编号
+		("acDescription", c_char * 32), # 描述信息
+	]
+
+	def GetDescription(self):
+		return _string_buffer_to_str(self.acDescription)
+
+#AE算法描述
+class tSdkAeAlgorithm(MvStructure):
+	_fields_ = [
+		("iIndex", c_int),				# 编号
+		("acDescription", c_char * 32), # 描述信息
+	]
+
+	def GetDescription(self):
+		return _string_buffer_to_str(self.acDescription)
+
+#RAW转RGB算法描述
+class tSdkBayerDecodeAlgorithm(MvStructure):
+	_fields_ = [
+		("iIndex", c_int),				# 编号
+		("acDescription", c_char * 32), # 描述信息
+	]
+
+	def GetDescription(self):
+		return _string_buffer_to_str(self.acDescription)
+
+#帧率统计信息
+class tSdkFrameStatistic(MvStructure):
+	_fields_ = [
+		("iTotal", c_int),        #当前采集的总帧数（包括错误帧）
+		("iCapture", c_int),      #当前采集的有效帧的数量    
+		("iLost", c_int),         #当前丢帧的数量    
+	]
+
+#相机输出的图像数据格式
+class tSdkMediaType(MvStructure):
+	_fields_ = [
+		("iIndex", c_int),				# 格式种类编号
+		("acDescription", c_char * 32), # 描述信息
+		("iMediaType", c_uint),			# 对应的图像格式编码，如CAMERA_MEDIA_TYPE_BAYGR8。
+	]
+
+	def GetDescription(self):
+		return _string_buffer_to_str(self.acDescription)
+
+#伽马的设定范围
+class tGammaRange(MvStructure):
+	_fields_ = [
+		("iMin", c_int),       #最小值
+		("iMax", c_int),       #最大值
+	]
+
+#对比度的设定范围
+class tContrastRange(MvStructure):
+	_fields_ = [
+		("iMin", c_int),       #最小值
+		("iMax", c_int),       #最大值
+	]
+
+#RGB三通道数字增益的设定范围
+class tRgbGainRange(MvStructure):
+	_fields_ = [
+		("iRGainMin", c_int),   #红色增益的最小值
+		("iRGainMax", c_int),   #红色增益的最大值
+		("iGGainMin", c_int),   #绿色增益的最小值
+		("iGGainMax", c_int),   #绿色增益的最大值
+		("iBGainMin", c_int),   #蓝色增益的最小值
+		("iBGainMax", c_int),   #蓝色增益的最大值
+	]
+
+#饱和度设定的范围
+class tSaturationRange(MvStructure):
+	_fields_ = [
+		("iMin", c_int),       #最小值
+		("iMax", c_int),       #最大值
+	]
+
+#锐化的设定范围
+class tSharpnessRange(MvStructure):
+	_fields_ = [
+		("iMin", c_int),       #最小值
+		("iMax", c_int),       #最大值
+	]
+
+#ISP模块的使能信息
+class tSdkIspCapacity(MvStructure):
+	_fields_ = [
+		("bMonoSensor", c_int),        #表示该型号相机是否为黑白相机,如果是黑白相机，则颜色相关的功能都无法调节
+		("bWbOnce", c_int),            #表示该型号相机是否支持手动白平衡功能  
+		("bAutoWb", c_int),            #表示该型号相机是否支持自动白平衡功能
+		("bAutoExposure", c_int),      #表示该型号相机是否支持自动曝光功能
+		("bManualExposure", c_int),    #表示该型号相机是否支持手动曝光功能
+		("bAntiFlick", c_int),         #表示该型号相机是否支持抗频闪功能
+		("bDeviceIsp", c_int),         #表示该型号相机是否支持硬件ISP功能
+		("bForceUseDeviceIsp", c_int), #bDeviceIsp和bForceUseDeviceIsp同时为TRUE时，表示强制只用硬件ISP，不可取消。
+		("bZoomHD", c_int),            #相机硬件是否支持图像缩放输出(只能是缩小)。
+	]
+
+# 定义整合的设备描述信息，这些信息可以用于动态构建UI
+class tSdkCameraCapbility(MvStructure):
+	_fields_ = [
+		("pTriggerDesc", POINTER(tSdkTrigger)),
+		("iTriggerDesc", c_int),	#触发模式的个数，即pTriggerDesc数组的大小
+		("pImageSizeDesc", POINTER(tSdkImageResolution)),
+		("iImageSizeDesc", c_int),	#预设分辨率的个数，即pImageSizeDesc数组的大小 
+		("pClrTempDesc", POINTER(tSdkColorTemperatureDes)),
+		("iClrTempDesc", c_int),	#预设色温个数
+		("pMediaTypeDesc", POINTER(tSdkMediaType)),
+		("iMediaTypeDesc", c_int),	#相机输出图像格式的种类个数，即pMediaTypeDesc数组的大小。
+		("pFrameSpeedDesc", POINTER(tSdkFrameSpeed)), #可调节帧速类型，对应界面上普通 高速 和超级三种速度设置
+		("iFrameSpeedDesc", c_int), #可调节帧速类型的个数，即pFrameSpeedDesc数组的大小。
+		("pPackLenDesc", POINTER(tSdkPackLength)), #传输包长度，一般用于网络设备
+		("iPackLenDesc", c_int), #可供选择的传输分包长度的个数，即pPackLenDesc数组的大小。 
+		("iOutputIoCounts", c_int),        #可编程输出IO的个数
+		("iInputIoCounts", c_int),         #可编程输入IO的个数
+		("pPresetLutDesc", POINTER(tSdkPresetLut)), #相机预设的LUT表
+		("iPresetLut", c_int),             #相机预设的LUT表的个数，即pPresetLutDesc数组的大小
+		("iUserDataMaxLen", c_int),        #指示该相机中用于保存用户数据区的最大长度。为0表示无。
+		("bParamInDevice", c_int),         #指示该设备是否支持从设备中读写参数组。1为支持，0不支持。
+		("pAeAlmSwDesc", POINTER(tSdkAeAlgorithm)),#软件自动曝光算法描述
+		("iAeAlmSwDesc", c_int),           #软件自动曝光算法个数
+		("pAeAlmHdDesc", POINTER(tSdkAeAlgorithm)),#硬件自动曝光算法描述，为NULL表示不支持硬件自动曝光
+		("iAeAlmHdDesc", c_int),           #硬件自动曝光算法个数，为0表示不支持硬件自动曝光
+		("pBayerDecAlmSwDesc", POINTER(tSdkBayerDecodeAlgorithm)),#软件Bayer转换为RGB数据的算法描述
+		("iBayerDecAlmSwDesc", c_int),     #软件Bayer转换为RGB数据的算法个数
+		("pBayerDecAlmHdDesc", POINTER(tSdkBayerDecodeAlgorithm)),#硬件Bayer转换为RGB数据的算法描述，为NULL表示不支持
+		("iBayerDecAlmHdDesc", c_int),     #硬件Bayer转换为RGB数据的算法个数，为0表示不支持
+
+		# 图像参数的调节范围定义,用于动态构建UI
+		("sExposeDesc", tSdkExpose),      #曝光的范围值
+		("sResolutionRange", tSdkResolutionRange), #分辨率范围描述  
+		("sRgbGainRange", tRgbGainRange),    #图像数字增益范围描述  
+		("sSaturationRange", tSaturationRange), #饱和度范围描述  
+		("sGammaRange", tGammaRange),      #伽马范围描述  
+		("sContrastRange", tContrastRange),   #对比度范围描述  
+		("sSharpnessRange", tSharpnessRange),  #锐化范围描述  
+		("sIspCapacity", tSdkIspCapacity),     #ISP能力描述
+	]
+
+#图像帧头信息
+class tSdkFrameHead(MvStructure):
+	_fields_ = [
+		("uiMediaType", c_uint),      # 图像格式,Image Format
+		("uBytes", c_uint),           # 图像数据字节数,Total bytes
+		("iWidth", c_int),            # 宽度 Image height
+		("iHeight", c_int),           # 高度 Image width
+		("iWidthZoomSw", c_int),      # 软件缩放的宽度,不需要进行软件裁剪的图像，此变量设置为0.
+		("iHeightZoomSw", c_int),     # 软件缩放的高度,不需要进行软件裁剪的图像，此变量设置为0.
+		("bIsTrigger", c_int),        # 指示是否为触发帧 is trigger 
+		("uiTimeStamp", c_uint),      # 该帧的采集时间，单位0.1毫秒 
+		("uiExpTime", c_uint),        # 当前图像的曝光值，单位为微秒us
+		("fAnalogGain", c_float),     # 当前图像的模拟增益倍数
+		("iGamma", c_int),            # 该帧图像的伽马设定值，仅当LUT模式为动态参数生成时有效，其余模式下为-1
+		("iContrast", c_int),         # 该帧图像的对比度设定值，仅当LUT模式为动态参数生成时有效，其余模式下为-1
+		("iSaturation", c_int),       # 该帧图像的饱和度设定值，对于黑白相机无意义，为0
+		("fRgain", c_float),          # 该帧图像处理的红色数字增益倍数，对于黑白相机无意义，为1
+		("fGgain", c_float),          # 该帧图像处理的绿色数字增益倍数，对于黑白相机无意义，为1
+		("fBgain", c_float),          # 该帧图像处理的蓝色数字增益倍数，对于黑白相机无意义，为1
+	]
+
+# Grabber统计信息
+class tSdkGrabberStat(MvStructure):
+	_fields_ = [
+		("Width", c_int),           # 帧图像大小
+		("Height", c_int),	        # 帧图像大小
+		("Disp", c_int),			# 显示帧数量
+		("Capture", c_int),		    # 采集的有效帧的数量
+		("Lost", c_int),			# 丢帧的数量
+		("Error", c_int),			# 错帧的数量
+		("DispFps", c_float),		# 显示帧率
+		("CapFps", c_float),		# 捕获帧率
+	]
+
+# 方法回调辅助类
+class method(object):
+	def __init__(self, FuncType):
+		super(method, self).__init__()
+		self.FuncType = FuncType
+		self.cache = {}
+
+	def __call__(self, cb):
+		self.cb = cb
+		return self
+
+	def __get__(self, obj, objtype):
+		try:
+			return self.cache[obj]
+		except KeyError as e:
+			def cl(*args):
+				return self.cb(obj, *args)
+			r = self.cache[obj] = self.FuncType(cl)
+			return r
+
+# 图像捕获的回调函数定义
+CAMERA_SNAP_PROC = CALLBACK_FUNC_TYPE(None, c_int, c_void_p, POINTER(tSdkFrameHead), c_void_p)
+
+# 相机连接状态回调
+CAMERA_CONNECTION_STATUS_CALLBACK = CALLBACK_FUNC_TYPE(None, c_int, c_uint, c_uint, c_void_p)
+
+# 异步抓图完成回调
+pfnCameraGrabberSaveImageComplete = CALLBACK_FUNC_TYPE(None, c_void_p, c_void_p, c_int, c_void_p)
+
+# 帧监听回调
+pfnCameraGrabberFrameListener = CALLBACK_FUNC_TYPE(c_int, c_void_p, c_int, c_void_p, POINTER(tSdkFrameHead), c_void_p)
+
+# 采集器图像捕获的回调
+pfnCameraGrabberFrameCallback = CALLBACK_FUNC_TYPE(None, c_void_p, c_void_p, POINTER(tSdkFrameHead), c_void_p)
+
+#-----------------------------------函数接口------------------------------------------
+
+# 线程局部存储
+_tls = local()
+
+# 存储最后一次SDK调用返回的错误码
+def GetLastError():
+	try:
+		return _tls.last_error
+	except AttributeError as e:
+		_tls.last_error = 0
+		return 0
+
+def SetLastError(err_code):
+	_tls.last_error = err_code
+
+def _string_buffer_to_str(buf):
+	s = buf if isinstance(buf, type(b'')) else buf.value
+
+	for codec in ('gbk', 'utf-8'):
+		try:
+			s = s.decode(codec)
+			break
+		except UnicodeDecodeError as e:
+			continue
+
+	if isinstance(s, str):
+		return s
+	else:
+		return s.encode('utf-8')
+
+def _str_to_string_buffer(str):
+	if type(str) is type(u''):
+		s = str.encode('gbk')
+	else:
+		s = str.decode('utf-8').encode('gbk')
+	return create_string_buffer(s)
+
+def CameraSdkInit(iLanguageSel):
+	err_code = _sdk.CameraSdkInit(iLanguageSel)
+	SetLastError(err_code)
+	return err_code
+	
+def CameraSetSysOption(optionName, value):
+	err_code = _sdk.CameraSetSysOption(_str_to_string_buffer(optionName), _str_to_string_buffer(str(value)))
+	SetLastError(err_code)
+	return err_code
+
+def CameraEnumerateDevice(MaxCount = 32):
+	Nums = c_int(MaxCount)
+	pCameraList = (tSdkCameraDevInfo * Nums.value)()
+	err_code = _sdk.CameraEnumerateDevice(pCameraList, byref(Nums))
+	SetLastError(err_code)
+	return pCameraList[0:Nums.value]
+
+def CameraEnumerateDeviceEx():
+	return _sdk.CameraEnumerateDeviceEx()
+
+def CameraIsOpened(pCameraInfo):
+	pOpened = c_int()
+	err_code = _sdk.CameraIsOpened(byref(pCameraInfo), byref(pOpened) )
+	SetLastError(err_code)
+	return pOpened.value != 0
+
+def CameraInit(pCameraInfo, emParamLoadMode = -1, emTeam = -1):
+	pCameraHandle = c_int()
+	err_code = _sdk.CameraInit(byref(pCameraInfo), emParamLoadMode, emTeam, byref(pCameraHandle))
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return pCameraHandle.value
+
+def CameraInitEx(iDeviceIndex, emParamLoadMode = -1, emTeam = -1):
+	pCameraHandle = c_int()
+	err_code = _sdk.CameraInitEx(iDeviceIndex, emParamLoadMode, emTeam, byref(pCameraHandle))
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return pCameraHandle.value
+
+def CameraInitEx2(CameraName):
+	pCameraHandle = c_int()
+	err_code = _sdk.CameraInitEx2(_str_to_string_buffer(CameraName), byref(pCameraHandle))
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return pCameraHandle.value
+
+def CameraSetCallbackFunction(hCamera, pCallBack, pContext = 0):
+	err_code = _sdk.CameraSetCallbackFunction(hCamera, pCallBack, c_void_p(pContext), None)
+	SetLastError(err_code)
+	return err_code
+
+def CameraUnInit(hCamera):
+	err_code = _sdk.CameraUnInit(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetInformation(hCamera):
+	pbuffer = c_char_p()
+	err_code = _sdk.CameraGetInformation(hCamera, byref(pbuffer) )
+	SetLastError(err_code)
+	if err_code == 0 and pbuffer.value is not None:
+		return _string_buffer_to_str(pbuffer)
+	return ''
+
+def CameraImageProcess(hCamera, pbyIn, pbyOut, pFrInfo):
+	err_code = _sdk.CameraImageProcess(hCamera, c_void_p(pbyIn), c_void_p(pbyOut), byref(pFrInfo))
+	SetLastError(err_code)
+	return err_code
+
+def CameraImageProcessEx(hCamera, pbyIn, pbyOut, pFrInfo, uOutFormat, uReserved):
+	err_code = _sdk.CameraImageProcessEx(hCamera, c_void_p(pbyIn), c_void_p(pbyOut), byref(pFrInfo), uOutFormat, uReserved)
+	SetLastError(err_code)
+	return err_code
+
+def CameraDisplayInit(hCamera, hWndDisplay):
+	err_code = _sdk.CameraDisplayInit(hCamera, hWndDisplay)
+	SetLastError(err_code)
+	return err_code
+
+def CameraDisplayRGB24(hCamera, pFrameBuffer, pFrInfo):
+	err_code = _sdk.CameraDisplayRGB24(hCamera, c_void_p(pFrameBuffer), byref(pFrInfo) )
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetDisplayMode(hCamera, iMode):
+	err_code = _sdk.CameraSetDisplayMode(hCamera, iMode)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetDisplayOffset(hCamera, iOffsetX, iOffsetY):
+	err_code = _sdk.CameraSetDisplayOffset(hCamera, iOffsetX, iOffsetY)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetDisplaySize(hCamera, iWidth, iHeight):
+	err_code = _sdk.CameraSetDisplaySize(hCamera, iWidth, iHeight)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetImageBuffer(hCamera, wTimes):
+	pbyBuffer = c_void_p()
+	pFrameInfo = tSdkFrameHead()
+	err_code = _sdk.CameraGetImageBuffer(hCamera, byref(pFrameInfo), byref(pbyBuffer), wTimes)
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return (pbyBuffer.value, pFrameInfo)
+
+def CameraGetImageBufferEx(hCamera, wTimes):
+	_sdk.CameraGetImageBufferEx.restype = c_void_p
+	piWidth = c_int()
+	piHeight = c_int()
+	pFrameBuffer = _sdk.CameraGetImageBufferEx(hCamera, byref(piWidth), byref(piHeight), wTimes)
+	err_code = CAMERA_STATUS_SUCCESS if pFrameBuffer else CAMERA_STATUS_TIME_OUT
+	SetLastError(err_code)
+	if pFrameBuffer:
+		return (pFrameBuffer, piWidth.value, piHeight.value)
+	else:
+		raise CameraException(err_code)
+
+def CameraSnapToBuffer(hCamera, wTimes):
+	pbyBuffer = c_void_p()
+	pFrameInfo = tSdkFrameHead()
+	err_code = _sdk.CameraSnapToBuffer(hCamera, byref(pFrameInfo), byref(pbyBuffer), wTimes)
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return (pbyBuffer.value, pFrameInfo)
+
+def CameraReleaseImageBuffer(hCamera, pbyBuffer):
+	err_code = _sdk.CameraReleaseImageBuffer(hCamera, c_void_p(pbyBuffer) )
+	SetLastError(err_code)
+	return err_code
+
+def CameraPlay(hCamera):
+	err_code = _sdk.CameraPlay(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraPause(hCamera):
+	err_code = _sdk.CameraPause(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraStop(hCamera):
+	err_code = _sdk.CameraStop(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraInitRecord(hCamera, iFormat, pcSavePath, b2GLimit, dwQuality, iFrameRate):
+	err_code = _sdk.CameraInitRecord(hCamera, iFormat, _str_to_string_buffer(pcSavePath), b2GLimit, dwQuality, iFrameRate)
+	SetLastError(err_code)
+	return err_code
+
+def CameraStopRecord(hCamera):
+	err_code = _sdk.CameraStopRecord(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraPushFrame(hCamera, pbyImageBuffer, pFrInfo):
+	err_code = _sdk.CameraPushFrame(hCamera, c_void_p(pbyImageBuffer), byref(pFrInfo) )
+	SetLastError(err_code)
+	return err_code
+
+def CameraSaveImage(hCamera, lpszFileName, pbyImageBuffer, pFrInfo, byFileType, byQuality):
+	err_code = _sdk.CameraSaveImage(hCamera, _str_to_string_buffer(lpszFileName), c_void_p(pbyImageBuffer), byref(pFrInfo), byFileType, byQuality)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSaveImageEx(hCamera, lpszFileName, pbyImageBuffer, uImageFormat, iWidth, iHeight, byFileType, byQuality):
+	err_code = _sdk.CameraSaveImageEx(hCamera, _str_to_string_buffer(lpszFileName), c_void_p(pbyImageBuffer), uImageFormat, iWidth, iHeight, byFileType, byQuality)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetImageResolution(hCamera):
+	psCurVideoSize = tSdkImageResolution()
+	err_code = _sdk.CameraGetImageResolution(hCamera, byref(psCurVideoSize) )
+	SetLastError(err_code)
+	return psCurVideoSize
+
+def CameraSetImageResolution(hCamera, pImageResolution):
+	err_code = _sdk.CameraSetImageResolution(hCamera, byref(pImageResolution) )
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetImageResolutionEx(hCamera, iIndex, Mode, ModeSize, x, y, width, height, ZoomWidth, ZoomHeight):
+	err_code = _sdk.CameraSetImageResolutionEx(hCamera, iIndex, Mode, ModeSize, x, y, width, height, ZoomWidth, ZoomHeight)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetMediaType(hCamera):
+	piMediaType = c_int()
+	err_code = _sdk.CameraGetMediaType(hCamera, byref(piMediaType) )
+	SetLastError(err_code)
+	return piMediaType.value
+
+def CameraSetMediaType(hCamera, iMediaType):
+	err_code = _sdk.CameraSetMediaType(hCamera, iMediaType)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetAeState(hCamera, bAeState):
+	err_code = _sdk.CameraSetAeState(hCamera, bAeState)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAeState(hCamera):
+	pAeState = c_int()
+	err_code = _sdk.CameraGetAeState(hCamera, byref(pAeState) )
+	SetLastError(err_code)
+	return pAeState.value
+
+def CameraSetSharpness(hCamera, iSharpness):
+	err_code = _sdk.CameraSetSharpness(hCamera, iSharpness)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetSharpness(hCamera):
+	piSharpness = c_int()
+	err_code = _sdk.CameraGetSharpness(hCamera, byref(piSharpness) )
+	SetLastError(err_code)
+	return piSharpness.value
+
+def CameraSetLutMode(hCamera, emLutMode):
+	err_code = _sdk.CameraSetLutMode(hCamera, emLutMode)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetLutMode(hCamera):
+	pemLutMode = c_int()
+	err_code = _sdk.CameraGetLutMode(hCamera, byref(pemLutMode) )
+	SetLastError(err_code)
+	return pemLutMode.value
+
+def CameraSelectLutPreset(hCamera, iSel):
+	err_code = _sdk.CameraSelectLutPreset(hCamera, iSel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetLutPresetSel(hCamera):
+	piSel = c_int()
+	err_code = _sdk.CameraGetLutPresetSel(hCamera, byref(piSel) )
+	SetLastError(err_code)
+	return piSel.value
+
+def CameraSetCustomLut(hCamera, iChannel, pLut):
+	pLutNative = (c_ushort * 4096)(*pLut)
+	err_code = _sdk.CameraSetCustomLut(hCamera, iChannel, pLutNative)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetCustomLut(hCamera, iChannel):
+	pLutNative = (c_ushort * 4096)()
+	err_code = _sdk.CameraGetCustomLut(hCamera, iChannel, pLutNative)
+	SetLastError(err_code)
+	return pLutNative[:]
+
+def CameraGetCurrentLut(hCamera, iChannel):
+	pLutNative = (c_ushort * 4096)()
+	err_code = _sdk.CameraGetCurrentLut(hCamera, iChannel, pLutNative)
+	SetLastError(err_code)
+	return pLutNative[:]
+
+def CameraSetWbMode(hCamera, bAuto):
+	err_code = _sdk.CameraSetWbMode(hCamera, bAuto)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetWbMode(hCamera):
+	pbAuto = c_int()
+	err_code = _sdk.CameraGetWbMode(hCamera, byref(pbAuto) )
+	SetLastError(err_code)
+	return pbAuto.value
+
+def CameraSetPresetClrTemp(hCamera, iSel):
+	err_code = _sdk.CameraSetPresetClrTemp(hCamera, iSel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetPresetClrTemp(hCamera):
+	piSel = c_int()
+	err_code = _sdk.CameraGetPresetClrTemp(hCamera, byref(piSel) )
+	SetLastError(err_code)
+	return piSel.value
+
+def CameraSetUserClrTempGain(hCamera, iRgain, iGgain, iBgain):
+	err_code = _sdk.CameraSetUserClrTempGain(hCamera, iRgain, iGgain, iBgain)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetUserClrTempGain(hCamera):
+	piRgain = c_int()
+	piGgain = c_int()
+	piBgain = c_int()
+	err_code = _sdk.CameraGetUserClrTempGain(hCamera, byref(piRgain), byref(piGgain), byref(piBgain) )
+	SetLastError(err_code)
+	return (piRgain.value, piGgain.value, piBgain.value)
+
+def CameraSetUserClrTempMatrix(hCamera, pMatrix):
+	pMatrixNative = (c_float * 9)(*pMatrix)
+	err_code = _sdk.CameraSetUserClrTempMatrix(hCamera, pMatrixNative)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetUserClrTempMatrix(hCamera):
+	pMatrixNative = (c_float * 9)()
+	err_code = _sdk.CameraGetUserClrTempMatrix(hCamera, pMatrixNative)
+	SetLastError(err_code)
+	return pMatrixNative[:]
+
+def CameraSetClrTempMode(hCamera, iMode):
+	err_code = _sdk.CameraSetClrTempMode(hCamera, iMode)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetClrTempMode(hCamera):
+	piMode = c_int()
+	err_code = _sdk.CameraGetClrTempMode(hCamera, byref(piMode) )
+	SetLastError(err_code)
+	return piMode.value
+
+def CameraSetOnceWB(hCamera):
+	err_code = _sdk.CameraSetOnceWB(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetOnceBB(hCamera):
+	err_code = _sdk.CameraSetOnceBB(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetAeTarget(hCamera, iAeTarget):
+	err_code = _sdk.CameraSetAeTarget(hCamera, iAeTarget)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAeTarget(hCamera):
+	piAeTarget = c_int()
+	err_code = _sdk.CameraGetAeTarget(hCamera, byref(piAeTarget) )
+	SetLastError(err_code)
+	return piAeTarget.value
+
+def CameraSetAeExposureRange(hCamera, fMinExposureTime, fMaxExposureTime):
+	err_code = _sdk.CameraSetAeExposureRange(hCamera, c_double(fMinExposureTime), c_double(fMaxExposureTime) )
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAeExposureRange(hCamera):
+	fMinExposureTime = c_double()
+	fMaxExposureTime = c_double()
+	err_code = _sdk.CameraGetAeExposureRange(hCamera, byref(fMinExposureTime), byref(fMaxExposureTime) )
+	SetLastError(err_code)
+	return (fMinExposureTime.value, fMaxExposureTime.value)
+
+def CameraSetAeAnalogGainRange(hCamera, iMinAnalogGain, iMaxAnalogGain):
+	err_code = _sdk.CameraSetAeAnalogGainRange(hCamera, iMinAnalogGain, iMaxAnalogGain)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAeAnalogGainRange(hCamera):
+	iMinAnalogGain = c_int()
+	iMaxAnalogGain = c_int()
+	err_code = _sdk.CameraGetAeAnalogGainRange(hCamera, byref(iMinAnalogGain), byref(iMaxAnalogGain) )
+	SetLastError(err_code)
+	return (iMinAnalogGain.value, iMaxAnalogGain.value)
+
+def CameraSetAeThreshold(hCamera, iThreshold):
+	err_code = _sdk.CameraSetAeThreshold(hCamera, iThreshold)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAeThreshold(hCamera):
+	iThreshold = c_int()
+	err_code = _sdk.CameraGetAeThreshold(hCamera, byref(iThreshold))
+	SetLastError(err_code)
+	return iThreshold.value
+
+def CameraSetExposureTime(hCamera, fExposureTime):
+	err_code = _sdk.CameraSetExposureTime(hCamera, c_double(fExposureTime) )
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetExposureLineTime(hCamera):
+	pfLineTime = c_double()
+	err_code = _sdk.CameraGetExposureLineTime(hCamera, byref(pfLineTime))
+	SetLastError(err_code)
+	return pfLineTime.value
+
+def CameraGetExposureTime(hCamera):
+	pfExposureTime = c_double()
+	err_code = _sdk.CameraGetExposureTime(hCamera, byref(pfExposureTime))
+	SetLastError(err_code)
+	return pfExposureTime.value
+
+def CameraGetExposureTimeRange(hCamera):
+	pfMin = c_double()
+	pfMax = c_double()
+	pfStep = c_double()
+	err_code = _sdk.CameraGetExposureTimeRange(hCamera, byref(pfMin), byref(pfMax), byref(pfStep))
+	SetLastError(err_code)
+	return (pfMin.value, pfMax.value, pfStep.value)
+
+def CameraSetAnalogGain(hCamera, iAnalogGain):
+	err_code = _sdk.CameraSetAnalogGain(hCamera, iAnalogGain)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAnalogGain(hCamera):
+	piAnalogGain = c_int()
+	err_code = _sdk.CameraGetAnalogGain(hCamera, byref(piAnalogGain))
+	SetLastError(err_code)
+	return piAnalogGain.value
+
+def CameraSetGain(hCamera, iRGain, iGGain, iBGain):
+	err_code = _sdk.CameraSetGain(hCamera, iRGain, iGGain, iBGain)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetGain(hCamera):
+	piRGain = c_int()
+	piGGain = c_int()
+	piBGain = c_int()
+	err_code = _sdk.CameraGetGain(hCamera, byref(piRGain), byref(piGGain), byref(piBGain))
+	SetLastError(err_code)
+	return (piRGain.value, piGGain.value, piBGain.value)
+
+def CameraSetGamma(hCamera, iGamma):
+	err_code = _sdk.CameraSetGamma(hCamera, iGamma)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetGamma(hCamera):
+	piGamma = c_int()
+	err_code = _sdk.CameraGetGamma(hCamera, byref(piGamma))
+	SetLastError(err_code)
+	return piGamma.value
+
+def CameraSetContrast(hCamera, iContrast):
+	err_code = _sdk.CameraSetContrast(hCamera, iContrast)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetContrast(hCamera):
+	piContrast = c_int()
+	err_code = _sdk.CameraGetContrast(hCamera, byref(piContrast))
+	SetLastError(err_code)
+	return piContrast.value
+
+def CameraSetSaturation(hCamera, iSaturation):
+	err_code = _sdk.CameraSetSaturation(hCamera, iSaturation)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetSaturation(hCamera):
+	piSaturation = c_int()
+	err_code = _sdk.CameraGetSaturation(hCamera, byref(piSaturation))
+	SetLastError(err_code)
+	return piSaturation.value
+
+def CameraSetMonochrome(hCamera, bEnable):
+	err_code = _sdk.CameraSetMonochrome(hCamera, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetMonochrome(hCamera):
+	pbEnable = c_int()
+	err_code = _sdk.CameraGetMonochrome(hCamera, byref(pbEnable))
+	SetLastError(err_code)
+	return pbEnable.value
+
+def CameraSetInverse(hCamera, bEnable):
+	err_code = _sdk.CameraSetInverse(hCamera, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetInverse(hCamera):
+	pbEnable = c_int()
+	err_code = _sdk.CameraGetInverse(hCamera, byref(pbEnable))
+	SetLastError(err_code)
+	return pbEnable.value
+
+def CameraSetAntiFlick(hCamera, bEnable):
+	err_code = _sdk.CameraSetAntiFlick(hCamera, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAntiFlick(hCamera):
+	pbEnable = c_int()
+	err_code = _sdk.CameraGetAntiFlick(hCamera, byref(pbEnable))
+	SetLastError(err_code)
+	return pbEnable.value
+
+def CameraGetLightFrequency(hCamera):
+	piFrequencySel = c_int()
+	err_code = _sdk.CameraGetLightFrequency(hCamera, byref(piFrequencySel))
+	SetLastError(err_code)
+	return piFrequencySel.value
+
+def CameraSetLightFrequency(hCamera, iFrequencySel):
+	err_code = _sdk.CameraSetLightFrequency(hCamera, iFrequencySel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetFrameSpeed(hCamera, iFrameSpeed):
+	err_code = _sdk.CameraSetFrameSpeed(hCamera, iFrameSpeed)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetFrameSpeed(hCamera):
+	piFrameSpeed = c_int()
+	err_code = _sdk.CameraGetFrameSpeed(hCamera, byref(piFrameSpeed))
+	SetLastError(err_code)
+	return piFrameSpeed.value
+
+def CameraSetParameterMode(hCamera, iMode):
+	err_code = _sdk.CameraSetParameterMode(hCamera, iMode)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetParameterMode(hCamera):
+	piTarget = c_int()
+	err_code = _sdk.CameraGetParameterMode(hCamera, byref(piTarget))
+	SetLastError(err_code)
+	return piTarget.value
+
+def CameraSetParameterMask(hCamera, uMask):
+	err_code = _sdk.CameraSetParameterMask(hCamera, uMask)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSaveParameter(hCamera, iTeam):
+	err_code = _sdk.CameraSaveParameter(hCamera, iTeam)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSaveParameterToFile(hCamera, sFileName):
+	err_code = _sdk.CameraSaveParameterToFile(hCamera, _str_to_string_buffer(sFileName))
+	SetLastError(err_code)
+	return err_code
+
+def CameraReadParameterFromFile(hCamera, sFileName):
+	err_code = _sdk.CameraReadParameterFromFile(hCamera, _str_to_string_buffer(sFileName))
+	SetLastError(err_code)
+	return err_code
+
+def CameraLoadParameter(hCamera, iTeam):
+	err_code = _sdk.CameraLoadParameter(hCamera, iTeam)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetCurrentParameterGroup(hCamera):
+	piTeam = c_int()
+	err_code = _sdk.CameraGetCurrentParameterGroup(hCamera, byref(piTeam))
+	SetLastError(err_code)
+	return piTeam.value
+
+def CameraSetTransPackLen(hCamera, iPackSel):
+	err_code = _sdk.CameraSetTransPackLen(hCamera, iPackSel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetTransPackLen(hCamera):
+	piPackSel = c_int()
+	err_code = _sdk.CameraGetTransPackLen(hCamera, byref(piPackSel))
+	SetLastError(err_code)
+	return piPackSel.value
+
+def CameraIsAeWinVisible(hCamera):
+	pbIsVisible = c_int()
+	err_code = _sdk.CameraIsAeWinVisible(hCamera, byref(pbIsVisible))
+	SetLastError(err_code)
+	return pbIsVisible.value
+
+def CameraSetAeWinVisible(hCamera, bIsVisible):
+	err_code = _sdk.CameraSetAeWinVisible(hCamera, bIsVisible)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAeWindow(hCamera):
+	piHOff = c_int()
+	piVOff = c_int()
+	piWidth = c_int()
+	piHeight = c_int()
+	err_code = _sdk.CameraGetAeWindow(hCamera, byref(piHOff), byref(piVOff), byref(piWidth), byref(piHeight))
+	SetLastError(err_code)
+	return (piHOff.value, piVOff.value, piWidth.value, piHeight.value)
+
+def CameraSetAeWindow(hCamera, iHOff, iVOff, iWidth, iHeight):
+	err_code = _sdk.CameraSetAeWindow(hCamera, iHOff, iVOff, iWidth, iHeight)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetMirror(hCamera, iDir, bEnable):
+	err_code = _sdk.CameraSetMirror(hCamera, iDir, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetMirror(hCamera, iDir):
+	pbEnable = c_int()
+	err_code = _sdk.CameraGetMirror(hCamera, iDir, byref(pbEnable))
+	SetLastError(err_code)
+	return pbEnable.value
+
+def CameraSetRotate(hCamera, iRot):
+	err_code = _sdk.CameraSetRotate(hCamera, iRot)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetRotate(hCamera):
+	iRot = c_int()
+	err_code = _sdk.CameraGetRotate(hCamera, byref(iRot))
+	SetLastError(err_code)
+	return iRot.value
+
+def CameraGetWbWindow(hCamera):
+	PiHOff = c_int()
+	PiVOff = c_int()
+	PiWidth = c_int()
+	PiHeight = c_int()
+	err_code = _sdk.CameraGetWbWindow(hCamera, byref(PiHOff), byref(PiVOff), byref(PiWidth), byref(PiHeight))
+	SetLastError(err_code)
+	return (PiHOff.value, PiVOff.value, PiWidth.value, PiHeight.value)
+
+def CameraSetWbWindow(hCamera, iHOff, iVOff, iWidth, iHeight):
+	err_code = _sdk.CameraSetWbWindow(hCamera, iHOff, iVOff, iWidth, iHeight)
+	SetLastError(err_code)
+	return err_code
+
+def CameraIsWbWinVisible(hCamera):
+	pbShow = c_int()
+	err_code = _sdk.CameraIsWbWinVisible(hCamera, byref(pbShow))
+	SetLastError(err_code)
+	return pbShow.value
+
+def CameraSetWbWinVisible(hCamera, bShow):
+	err_code = _sdk.CameraSetWbWinVisible(hCamera, bShow)
+	SetLastError(err_code)
+	return err_code
+
+def CameraImageOverlay(hCamera, pRgbBuffer, pFrInfo):
+	err_code = _sdk.CameraImageOverlay(hCamera, c_void_p(pRgbBuffer), byref(pFrInfo))
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetCrossLine(hCamera, iLine, x, y, uColor, bVisible):
+	err_code = _sdk.CameraSetCrossLine(hCamera, iLine, x, y, uColor, bVisible)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetCrossLine(hCamera, iLine):
+	px = c_int()
+	py = c_int()
+	pcolor = c_uint()
+	pbVisible = c_int()
+	err_code = _sdk.CameraGetCrossLine(hCamera, iLine, byref(px), byref(py), byref(pcolor), byref(pbVisible))
+	SetLastError(err_code)
+	return (px.value, py.value, pcolor.value, pbVisible.value)
+
+def CameraGetCapability(hCamera):
+	pCameraInfo = tSdkCameraCapbility()
+	err_code = _sdk.CameraGetCapability(hCamera, byref(pCameraInfo))
+	SetLastError(err_code)
+	return pCameraInfo
+
+def CameraWriteSN(hCamera, pbySN, iLevel):
+	err_code = _sdk.CameraWriteSN(hCamera, _str_to_string_buffer(pbySN), iLevel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraReadSN(hCamera, iLevel):
+	pbySN = create_string_buffer(64)
+	err_code = _sdk.CameraReadSN(hCamera, pbySN, iLevel)
+	SetLastError(err_code)
+	return _string_buffer_to_str(pbySN)
+
+def CameraSetTriggerDelayTime(hCamera, uDelayTimeUs):
+	err_code = _sdk.CameraSetTriggerDelayTime(hCamera, uDelayTimeUs)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetTriggerDelayTime(hCamera):
+	puDelayTimeUs = c_uint()
+	err_code = _sdk.CameraGetTriggerDelayTime(hCamera, byref(puDelayTimeUs))
+	SetLastError(err_code)
+	return puDelayTimeUs.value
+
+def CameraSetTriggerCount(hCamera, iCount):
+	err_code = _sdk.CameraSetTriggerCount(hCamera, iCount)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetTriggerCount(hCamera):
+	piCount = c_int()
+	err_code = _sdk.CameraGetTriggerCount(hCamera, byref(piCount))
+	SetLastError(err_code)
+	return piCount.value
+
+def CameraSoftTrigger(hCamera):
+	err_code = _sdk.CameraSoftTrigger(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetTriggerMode(hCamera, iModeSel):
+	err_code = _sdk.CameraSetTriggerMode(hCamera, iModeSel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetTriggerMode(hCamera):
+	piModeSel = c_int()
+	err_code = _sdk.CameraGetTriggerMode(hCamera, byref(piModeSel))
+	SetLastError(err_code)
+	return piModeSel.value
+
+def CameraSetStrobeMode(hCamera, iMode):
+	err_code = _sdk.CameraSetStrobeMode(hCamera, iMode)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetStrobeMode(hCamera):
+	piMode = c_int()
+	err_code = _sdk.CameraGetStrobeMode(hCamera, byref(piMode))
+	SetLastError(err_code)
+	return piMode.value
+
+def CameraSetStrobeDelayTime(hCamera, uDelayTimeUs):
+	err_code = _sdk.CameraSetStrobeDelayTime(hCamera, uDelayTimeUs)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetStrobeDelayTime(hCamera):
+	upDelayTimeUs = c_uint()
+	err_code = _sdk.CameraGetStrobeDelayTime(hCamera, byref(upDelayTimeUs))
+	SetLastError(err_code)
+	return upDelayTimeUs.value
+
+def CameraSetStrobePulseWidth(hCamera, uTimeUs):
+	err_code = _sdk.CameraSetStrobePulseWidth(hCamera, uTimeUs)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetStrobePulseWidth(hCamera):
+	upTimeUs = c_uint()
+	err_code = _sdk.CameraGetStrobePulseWidth(hCamera, byref(upTimeUs))
+	SetLastError(err_code)
+	return upTimeUs.value
+
+def CameraSetStrobePolarity(hCamera, uPolarity):
+	err_code = _sdk.CameraSetStrobePolarity(hCamera, uPolarity)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetStrobePolarity(hCamera):
+	upPolarity = c_uint()
+	err_code = _sdk.CameraGetStrobePolarity(hCamera, byref(upPolarity))
+	SetLastError(err_code)
+	return upPolarity.value
+
+def CameraSetExtTrigSignalType(hCamera, iType):
+	err_code = _sdk.CameraSetExtTrigSignalType(hCamera, iType)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetExtTrigSignalType(hCamera):
+	ipType = c_int()
+	err_code = _sdk.CameraGetExtTrigSignalType(hCamera, byref(ipType))
+	SetLastError(err_code)
+	return ipType.value
+
+def CameraSetExtTrigShutterType(hCamera, iType):
+	err_code = _sdk.CameraSetExtTrigShutterType(hCamera, iType)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetExtTrigShutterType(hCamera):
+	ipType = c_int()
+	err_code = _sdk.CameraGetExtTrigShutterType(hCamera, byref(ipType))
+	SetLastError(err_code)
+	return ipType.value
+
+def CameraSetExtTrigDelayTime(hCamera, uDelayTimeUs):
+	err_code = _sdk.CameraSetExtTrigDelayTime(hCamera, uDelayTimeUs)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetExtTrigDelayTime(hCamera):
+	upDelayTimeUs = c_uint()
+	err_code = _sdk.CameraGetExtTrigDelayTime(hCamera, byref(upDelayTimeUs))
+	SetLastError(err_code)
+	return upDelayTimeUs.value
+
+def CameraSetExtTrigJitterTime(hCamera, uTimeUs):
+	err_code = _sdk.CameraSetExtTrigJitterTime(hCamera, uTimeUs)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetExtTrigJitterTime(hCamera):
+	upTimeUs = c_uint()
+	err_code = _sdk.CameraGetExtTrigJitterTime(hCamera, byref(upTimeUs))
+	SetLastError(err_code)
+	return upTimeUs.value
+
+def CameraGetExtTrigCapability(hCamera):
+	puCapabilityMask = c_uint()
+	err_code = _sdk.CameraGetExtTrigCapability(hCamera, byref(puCapabilityMask))
+	SetLastError(err_code)
+	return puCapabilityMask.value
+
+def CameraPauseLevelTrigger(hCamera):
+	err_code = _sdk.CameraPauseLevelTrigger(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetResolutionForSnap(hCamera):
+	pImageResolution = tSdkImageResolution()
+	err_code = _sdk.CameraGetResolutionForSnap(hCamera, byref(pImageResolution))
+	SetLastError(err_code)
+	return pImageResolution
+
+def CameraSetResolutionForSnap(hCamera, pImageResolution):
+	err_code = _sdk.CameraSetResolutionForSnap(hCamera, byref(pImageResolution))
+	SetLastError(err_code)
+	return err_code
+
+def CameraCustomizeResolution(hCamera):
+	pImageCustom = tSdkImageResolution()
+	err_code = _sdk.CameraCustomizeResolution(hCamera, byref(pImageCustom))
+	SetLastError(err_code)
+	return pImageCustom
+
+def CameraCustomizeReferWin(hCamera, iWinType, hParent):
+	piHOff = c_int()
+	piVOff = c_int()
+	piWidth = c_int()
+	piHeight = c_int()
+	err_code = _sdk.CameraCustomizeReferWin(hCamera, iWinType, hParent, byref(piHOff), byref(piVOff), byref(piWidth), byref(piHeight))
+	SetLastError(err_code)
+	return (piHOff.value, piVOff.value, piWidth.value, piHeight.value)
+
+def CameraShowSettingPage(hCamera, bShow):
+	err_code = _sdk.CameraShowSettingPage(hCamera, bShow)
+	SetLastError(err_code)
+	return err_code
+
+def CameraCreateSettingPage(hCamera, hParent, pWinText, pCallbackFunc = None, pCallbackCtx = 0, uReserved = 0):
+	err_code = _sdk.CameraCreateSettingPage(hCamera, hParent, _str_to_string_buffer(pWinText), pCallbackFunc, c_void_p(pCallbackCtx), uReserved)
+	SetLastError(err_code)
+	return err_code
+
+def CameraCreateSettingPageEx(hCamera):
+	err_code = _sdk.CameraCreateSettingPageEx(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetActiveSettingSubPage(hCamera, index):
+	err_code = _sdk.CameraSetActiveSettingSubPage(hCamera, index)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetSettingPageParent(hCamera, hParentWnd, Flags):
+	err_code = _sdk.CameraSetSettingPageParent(hCamera, hParentWnd, Flags)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetSettingPageHWnd(hCamera):
+	hWnd = c_void_p()
+	err_code = _sdk.CameraGetSettingPageHWnd(hCamera, byref(hWnd))
+	SetLastError(err_code)
+	return hWnd.value
+
+def CameraSpecialControl(hCamera, dwCtrlCode, dwParam, lpData):
+	err_code = _sdk.CameraSpecialControl(hCamera, dwCtrlCode, dwParam, c_void_p(lpData) )
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetFrameStatistic(hCamera):
+	psFrameStatistic = tSdkFrameStatistic()
+	err_code = _sdk.CameraGetFrameStatistic(hCamera, byref(psFrameStatistic))
+	SetLastError(err_code)
+	return psFrameStatistic
+
+def CameraSetNoiseFilter(hCamera, bEnable):
+	err_code = _sdk.CameraSetNoiseFilter(hCamera, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetNoiseFilterState(hCamera):
+	pEnable = c_int()
+	err_code = _sdk.CameraGetNoiseFilterState(hCamera, byref(pEnable))
+	SetLastError(err_code)
+	return pEnable.value
+
+def CameraRstTimeStamp(hCamera):
+	err_code = _sdk.CameraRstTimeStamp(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSaveUserData(hCamera, uStartAddr, pbData):
+	err_code = _sdk.CameraSaveUserData(hCamera, uStartAddr, pbData, len(pbData))
+	SetLastError(err_code)
+	return err_code
+
+def CameraLoadUserData(hCamera, uStartAddr, ilen):
+	pbData = create_string_buffer(ilen)
+	err_code = _sdk.CameraLoadUserData(hCamera, uStartAddr, pbData, ilen)
+	SetLastError(err_code)
+	return pbData[:]
+
+def CameraGetFriendlyName(hCamera):
+	pName = create_string_buffer(64)
+	err_code = _sdk.CameraGetFriendlyName(hCamera, pName)
+	SetLastError(err_code)
+	return _string_buffer_to_str(pName)
+
+def CameraSetFriendlyName(hCamera, pName):
+	pNameBuf = _str_to_string_buffer(pName)
+	resize(pNameBuf, 64)
+	err_code = _sdk.CameraSetFriendlyName(hCamera, pNameBuf)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSdkGetVersionString():
+	pVersionString = create_string_buffer(64)
+	err_code = _sdk.CameraSdkGetVersionString(pVersionString)
+	SetLastError(err_code)
+	return _string_buffer_to_str(pVersionString)
+
+def CameraCheckFwUpdate(hCamera):
+	pNeedUpdate = c_int()
+	err_code = _sdk.CameraCheckFwUpdate(hCamera, byref(pNeedUpdate))
+	SetLastError(err_code)
+	return pNeedUpdate.value
+
+def CameraGetFirmwareVersion(hCamera):
+	pVersion = create_string_buffer(64)
+	err_code = _sdk.CameraGetFirmwareVersion(hCamera, pVersion)
+	SetLastError(err_code)
+	return _string_buffer_to_str(pVersion)
+
+def CameraGetEnumInfo(hCamera):
+	pCameraInfo = tSdkCameraDevInfo()
+	err_code = _sdk.CameraGetEnumInfo(hCamera, byref(pCameraInfo))
+	SetLastError(err_code)
+	return pCameraInfo
+
+def CameraGetInerfaceVersion(hCamera):
+	pVersion = create_string_buffer(64)
+	err_code = _sdk.CameraGetInerfaceVersion(hCamera, pVersion)
+	SetLastError(err_code)
+	return _string_buffer_to_str(pVersion)
+
+def CameraSetIOState(hCamera, iOutputIOIndex, uState):
+	err_code = _sdk.CameraSetIOState(hCamera, iOutputIOIndex, uState)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetIOStateEx(hCamera, iOutputIOIndex, uState):
+	err_code = _sdk.CameraSetIOStateEx(hCamera, iOutputIOIndex, uState)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetOutPutIOState(hCamera, iOutputIOIndex):
+	puState = c_int()
+	err_code = _sdk.CameraGetOutPutIOState(hCamera, iOutputIOIndex, byref(puState))
+	SetLastError(err_code)
+	return puState.value
+
+def CameraGetOutPutIOStateEx(hCamera, iOutputIOIndex):
+	puState = c_int()
+	err_code = _sdk.CameraGetOutPutIOStateEx(hCamera, iOutputIOIndex, byref(puState))
+	SetLastError(err_code)
+	return puState.value
+
+def CameraGetIOState(hCamera, iInputIOIndex):
+	puState = c_int()
+	err_code = _sdk.CameraGetIOState(hCamera, iInputIOIndex, byref(puState))
+	SetLastError(err_code)
+	return puState.value
+
+def CameraGetIOStateEx(hCamera, iInputIOIndex):
+	puState = c_int()
+	err_code = _sdk.CameraGetIOStateEx(hCamera, iInputIOIndex, byref(puState))
+	SetLastError(err_code)
+	return puState.value
+
+def CameraSetInPutIOMode(hCamera, iInputIOIndex, iMode):
+	err_code = _sdk.CameraSetInPutIOMode(hCamera, iInputIOIndex, iMode)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetOutPutIOMode(hCamera, iOutputIOIndex, iMode):
+	err_code = _sdk.CameraSetOutPutIOMode(hCamera, iOutputIOIndex, iMode)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetOutPutPWM(hCamera, iOutputIOIndex, iCycle, uDuty):
+	err_code = _sdk.CameraSetOutPutPWM(hCamera, iOutputIOIndex, iCycle, uDuty)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetAeAlgorithm(hCamera, iIspProcessor, iAeAlgorithmSel):
+	err_code = _sdk.CameraSetAeAlgorithm(hCamera, iIspProcessor, iAeAlgorithmSel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAeAlgorithm(hCamera, iIspProcessor):
+	piAlgorithmSel = c_int()
+	err_code = _sdk.CameraGetAeAlgorithm(hCamera, iIspProcessor, byref(piAlgorithmSel))
+	SetLastError(err_code)
+	return piAlgorithmSel.value
+
+def CameraSetBayerDecAlgorithm(hCamera, iIspProcessor, iAlgorithmSel):
+	err_code = _sdk.CameraSetBayerDecAlgorithm(hCamera, iIspProcessor, iAlgorithmSel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetBayerDecAlgorithm(hCamera, iIspProcessor):
+	piAlgorithmSel = c_int()
+	err_code = _sdk.CameraGetBayerDecAlgorithm(hCamera, iIspProcessor, byref(piAlgorithmSel))
+	SetLastError(err_code)
+	return piAlgorithmSel.value
+
+def CameraSetIspProcessor(hCamera, iIspProcessor):
+	err_code = _sdk.CameraSetIspProcessor(hCamera, iIspProcessor)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetIspProcessor(hCamera):
+	piIspProcessor = c_int()
+	err_code = _sdk.CameraGetIspProcessor(hCamera, byref(piIspProcessor))
+	SetLastError(err_code)
+	return piIspProcessor.value
+
+def CameraSetBlackLevel(hCamera, iBlackLevel):
+	err_code = _sdk.CameraSetBlackLevel(hCamera, iBlackLevel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetBlackLevel(hCamera):
+	piBlackLevel = c_int()
+	err_code = _sdk.CameraGetBlackLevel(hCamera, byref(piBlackLevel))
+	SetLastError(err_code)
+	return piBlackLevel.value
+
+def CameraSetWhiteLevel(hCamera, iWhiteLevel):
+	err_code = _sdk.CameraSetWhiteLevel(hCamera, iWhiteLevel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetWhiteLevel(hCamera):
+	piWhiteLevel = c_int()
+	err_code = _sdk.CameraGetWhiteLevel(hCamera, byref(piWhiteLevel))
+	SetLastError(err_code)
+	return piWhiteLevel.value
+
+def CameraSetIspOutFormat(hCamera, uFormat):
+	err_code = _sdk.CameraSetIspOutFormat(hCamera, uFormat)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetIspOutFormat(hCamera):
+	puFormat = c_int()
+	err_code = _sdk.CameraGetIspOutFormat(hCamera, byref(puFormat))
+	SetLastError(err_code)
+	return puFormat.value
+
+def CameraGetErrorString(iStatusCode):
+	_sdk.CameraGetErrorString.restype = c_char_p
+	msg = _sdk.CameraGetErrorString(iStatusCode)
+	if msg:
+		return _string_buffer_to_str(msg)
+	else:
+		return ''
+
+def CameraGetImageBufferEx2(hCamera, pImageData, uOutFormat, wTimes):
+	piWidth = c_int()
+	piHeight = c_int()
+	err_code = _sdk.CameraGetImageBufferEx2(hCamera, c_void_p(pImageData), uOutFormat, byref(piWidth), byref(piHeight), wTimes)
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return (piWidth.value, piHeight.value)
+
+def CameraGetImageBufferEx3(hCamera, pImageData, uOutFormat, wTimes):
+	piWidth = c_int()
+	piHeight = c_int()
+	puTimeStamp = c_int()
+	err_code = _sdk.CameraGetImageBufferEx3(hCamera, c_void_p(pImageData), uOutFormat, byref(piWidth), byref(piHeight), byref(puTimeStamp), wTimes)
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return (piWidth.value, piHeight.value, puTimeStamp.value)
+
+def CameraGetCapabilityEx2(hCamera):
+	pMaxWidth = c_int()
+	pMaxHeight = c_int()
+	pbColorCamera = c_int()
+	err_code = _sdk.CameraGetCapabilityEx2(hCamera, byref(pMaxWidth), byref(pMaxHeight), byref(pbColorCamera))
+	SetLastError(err_code)
+	return (pMaxWidth.value, pMaxHeight.value, pbColorCamera.value)
+
+def CameraReConnect(hCamera):
+	err_code = _sdk.CameraReConnect(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraConnectTest(hCamera):
+	err_code = _sdk.CameraConnectTest(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetLedEnable(hCamera, index, enable):
+	err_code = _sdk.CameraSetLedEnable(hCamera, index, enable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetLedEnable(hCamera, index):
+	enable = c_int()
+	err_code = _sdk.CameraGetLedEnable(hCamera, index, byref(enable))
+	SetLastError(err_code)
+	return enable.value
+
+def CameraSetLedOnOff(hCamera, index, onoff):
+	err_code = _sdk.CameraSetLedOnOff(hCamera, index, onoff)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetLedOnOff(hCamera, index):
+	onoff = c_int()
+	err_code = _sdk.CameraGetLedOnOff(hCamera, index, byref(onoff))
+	SetLastError(err_code)
+	return onoff.value
+
+def CameraSetLedDuration(hCamera, index, duration):
+	err_code = _sdk.CameraSetLedDuration(hCamera, index, duration)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetLedDuration(hCamera, index):
+	duration = c_uint()
+	err_code = _sdk.CameraGetLedDuration(hCamera, index, byref(duration))
+	SetLastError(err_code)
+	return duration.value
+
+def CameraSetLedBrightness(hCamera, index, uBrightness):
+	err_code = _sdk.CameraSetLedBrightness(hCamera, index, uBrightness)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetLedBrightness(hCamera, index):
+	uBrightness = c_uint()
+	err_code = _sdk.CameraGetLedBrightness(hCamera, index, byref(uBrightness))
+	SetLastError(err_code)
+	return uBrightness.value
+
+def CameraEnableTransferRoi(hCamera, uEnableMask):
+	err_code = _sdk.CameraEnableTransferRoi(hCamera, uEnableMask)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetTransferRoi(hCamera, index, X1, Y1, X2, Y2):
+	err_code = _sdk.CameraSetTransferRoi(hCamera, index, X1, Y1, X2, Y2)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetTransferRoi(hCamera, index):
+	pX1 = c_uint()
+	pY1 = c_uint()
+	pX2 = c_uint()
+	pY2 = c_uint()
+	err_code = _sdk.CameraGetTransferRoi(hCamera, index, byref(pX1), byref(pY1), byref(pX2), byref(pY2))
+	SetLastError(err_code)
+	return (pX1.value, pY1.value, pX2.value, pY2.value)
+
+def CameraAlignMalloc(size, align = 16):
+	_sdk.CameraAlignMalloc.restype = c_void_p
+	r = _sdk.CameraAlignMalloc(size, align)
+	return r
+
+def CameraAlignFree(membuffer):
+	_sdk.CameraAlignFree(c_void_p(membuffer))
+
+def CameraSetAutoConnect(hCamera, bEnable):
+	err_code = _sdk.CameraSetAutoConnect(hCamera, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAutoConnect(hCamera):
+	pbEnable = c_int()
+	err_code = _sdk.CameraGetAutoConnect(hCamera, byref(pbEnable))
+	SetLastError(err_code)
+	return pbEnable.value
+
+def CameraGetReConnectCounts(hCamera):
+	puCounts = c_int()
+	err_code = _sdk.CameraGetReConnectCounts(hCamera, byref(puCounts))
+	SetLastError(err_code)
+	return puCounts.value
+
+def CameraSetSingleGrabMode(hCamera, bEnable):
+	err_code = _sdk.CameraSetSingleGrabMode(hCamera, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetSingleGrabMode(hCamera):
+	pbEnable = c_int()
+	err_code = _sdk.CameraGetSingleGrabMode(hCamera, byref(pbEnable))
+	SetLastError(err_code)
+	return pbEnable.value
+
+def CameraRestartGrab(hCamera):
+	err_code = _sdk.CameraRestartGrab(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraEvaluateImageDefinition(hCamera, iAlgorithSel, pbyIn, pFrInfo):
+	DefinitionValue = c_double()
+	err_code = _sdk.CameraEvaluateImageDefinition(hCamera, iAlgorithSel, c_void_p(pbyIn), byref(pFrInfo), byref(DefinitionValue))
+	SetLastError(err_code)
+	return DefinitionValue.value
+
+def CameraDrawText(pRgbBuffer, pFrInfo, pFontFileName, FontWidth, FontHeight, pText, Left, Top, Width, Height, TextColor, uFlags):
+	err_code = _sdk.CameraDrawText(c_void_p(pRgbBuffer), byref(pFrInfo), _str_to_string_buffer(pFontFileName), FontWidth, FontHeight, _str_to_string_buffer(pText), Left, Top, Width, Height, TextColor, uFlags)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGigeEnumerateDevice(ipList, MaxCount = 32):
+	if type(ipList) in (list, tuple):
+		ipList = map(lambda x: _str_to_string_buffer(x), ipList)
+	else:
+		ipList = (_str_to_string_buffer(ipList),)
+	numIP = len(ipList)
+	ppIpList = (c_void_p * numIP)(*map(lambda x: addressof(x), ipList))
+	Nums = c_int(MaxCount)
+	pCameraList = (tSdkCameraDevInfo * Nums.value)()
+	err_code = _sdk.CameraGigeEnumerateDevice(ppIpList, numIP, pCameraList, byref(Nums))
+	SetLastError(err_code)
+	return pCameraList[0:Nums.value]
+
+def CameraGigeGetIp(pCameraInfo):
+	CamIp = create_string_buffer(32)
+	CamMask = create_string_buffer(32)
+	CamGateWay = create_string_buffer(32)
+	EtIp = create_string_buffer(32)
+	EtMask = create_string_buffer(32)
+	EtGateWay = create_string_buffer(32)
+	err_code = _sdk.CameraGigeGetIp(byref(pCameraInfo), CamIp, CamMask, CamGateWay, EtIp, EtMask, EtGateWay)
+	SetLastError(err_code)
+	return (_string_buffer_to_str(CamIp), _string_buffer_to_str(CamMask), _string_buffer_to_str(CamGateWay), 
+		_string_buffer_to_str(EtIp), _string_buffer_to_str(EtMask), _string_buffer_to_str(EtGateWay) )
+
+def CameraGigeSetIp(pCameraInfo, Ip, SubMask, GateWay, bPersistent):
+	err_code = _sdk.CameraGigeSetIp(byref(pCameraInfo), 
+		_str_to_string_buffer(Ip), _str_to_string_buffer(SubMask), _str_to_string_buffer(GateWay), bPersistent)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGigeGetMac(pCameraInfo):
+	CamMac = create_string_buffer(32)
+	EtMac = create_string_buffer(32)
+	err_code = _sdk.CameraGigeGetMac(byref(pCameraInfo), CamMac, EtMac)
+	SetLastError(err_code)
+	return (_string_buffer_to_str(CamMac), _string_buffer_to_str(EtMac) )
+
+def CameraEnableFastResponse(hCamera):
+	err_code = _sdk.CameraEnableFastResponse(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetCorrectDeadPixel(hCamera, bEnable):
+	err_code = _sdk.CameraSetCorrectDeadPixel(hCamera, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetCorrectDeadPixel(hCamera):
+	pbEnable = c_int()
+	err_code = _sdk.CameraGetCorrectDeadPixel(hCamera, byref(pbEnable))
+	SetLastError(err_code)
+	return pbEnable.value
+
+def CameraFlatFieldingCorrectSetEnable(hCamera, bEnable):
+	err_code = _sdk.CameraFlatFieldingCorrectSetEnable(hCamera, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraFlatFieldingCorrectGetEnable(hCamera):
+	pbEnable = c_int()
+	err_code = _sdk.CameraFlatFieldingCorrectGetEnable(hCamera, byref(pbEnable))
+	SetLastError(err_code)
+	return pbEnable.value
+
+def CameraFlatFieldingCorrectSetParameter(hCamera, pDarkFieldingImage, pDarkFieldingFrInfo, pLightFieldingImage, pLightFieldingFrInfo):
+	err_code = _sdk.CameraFlatFieldingCorrectSetParameter(hCamera, c_void_p(pDarkFieldingImage), byref(pDarkFieldingFrInfo), c_void_p(pLightFieldingImage), byref(pLightFieldingFrInfo))
+	SetLastError(err_code)
+	return err_code
+
+def CameraFlatFieldingCorrectGetParameterState(hCamera):
+	pbValid = c_int()
+	pFilePath = create_string_buffer(1024)
+	err_code = _sdk.CameraFlatFieldingCorrectGetParameterState(hCamera, byref(pbValid), pFilePath)
+	SetLastError(err_code)
+	return (pbValid.value, _string_buffer_to_str(pFilePath) )
+
+def CameraFlatFieldingCorrectSaveParameterToFile(hCamera, pszFileName):
+	err_code = _sdk.CameraFlatFieldingCorrectSaveParameterToFile(hCamera, _str_to_string_buffer(pszFileName))
+	SetLastError(err_code)
+	return err_code
+
+def CameraFlatFieldingCorrectLoadParameterFromFile(hCamera, pszFileName):
+	err_code = _sdk.CameraFlatFieldingCorrectLoadParameterFromFile(hCamera, _str_to_string_buffer(pszFileName))
+	SetLastError(err_code)
+	return err_code
+
+def CameraCommonCall(hCamera, pszCall, uResultBufSize):
+	pszResult = create_string_buffer(uResultBufSize) if uResultBufSize > 0 else None
+	err_code = _sdk.CameraCommonCall(hCamera, _str_to_string_buffer(pszCall), pszResult, uResultBufSize)
+	SetLastError(err_code)
+	return _string_buffer_to_str(pszResult) if pszResult else ''
+
+def CameraSetDenoise3DParams(hCamera, bEnable, nCount, Weights):
+	assert(nCount >= 2 and nCount <= 8)
+	if Weights:
+		assert(len(Weights) == nCount)
+		WeightsNative = (c_float * nCount)(*Weights)
+	else:
+		WeightsNative = None
+	err_code = _sdk.CameraSetDenoise3DParams(hCamera, bEnable, nCount, WeightsNative)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetDenoise3DParams(hCamera):
+	bEnable = c_int()
+	nCount = c_int()
+	bUseWeight = c_int()
+	Weights = (c_float * 8)()
+	err_code = _sdk.CameraGetDenoise3DParams(hCamera, byref(bEnable), byref(nCount), byref(bUseWeight), Weights)
+	SetLastError(err_code)
+	bEnable, nCount, bUseWeight = bEnable.value, nCount.value, bUseWeight.value
+	if bUseWeight:
+		Weights = Weights[:nCount]
+	else:
+		Weights = None
+	return (bEnable, nCount, bUseWeight, Weights)
+
+def CameraManualDenoise3D(InFramesHead, InFramesData, nCount, Weights, OutFrameHead, OutFrameData):
+	assert(nCount > 0)
+	assert(len(InFramesData) == nCount)
+	assert(Weights is None or len(Weights) == nCount)
+	InFramesDataNative = (c_void_p * nCount)(*InFramesData)
+	WeightsNative = (c_float * nCount)(*Weights) if Weights else None
+	err_code = _sdk.CameraManualDenoise3D(byref(InFramesHead), InFramesDataNative, nCount, WeightsNative, byref(OutFrameHead), c_void_p(OutFrameData))
+	SetLastError(err_code)
+	return err_code
+
+def CameraCustomizeDeadPixels(hCamera, hParent):
+	err_code = _sdk.CameraCustomizeDeadPixels(hCamera, hParent)
+	SetLastError(err_code)
+	return err_code
+
+def CameraReadDeadPixels(hCamera):
+	pNumPixel = c_int()
+	err_code = _sdk.CameraReadDeadPixels(hCamera, None, None, byref(pNumPixel))
+	SetLastError(err_code)
+	if pNumPixel.value < 1:
+		return None
+	UShortArray = c_ushort * pNumPixel.value
+	pRows = UShortArray()
+	pCols = UShortArray()
+	err_code = _sdk.CameraReadDeadPixels(hCamera, pRows, pCols, byref(pNumPixel))
+	SetLastError(err_code)
+	if err_code == 0:
+		pNumPixel = pNumPixel.value
+	else:
+		pNumPixel = 0
+	return (pRows[:pNumPixel], pCols[:pNumPixel])
+
+def CameraAddDeadPixels(hCamera, pRows, pCols, NumPixel):
+	UShortArray = c_ushort * NumPixel
+	pRowsNative = UShortArray(*pRows)
+	pColsNative = UShortArray(*pCols)
+	err_code = _sdk.CameraAddDeadPixels(hCamera, pRowsNative, pColsNative, NumPixel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraRemoveDeadPixels(hCamera, pRows, pCols, NumPixel):
+	UShortArray = c_ushort * NumPixel
+	pRowsNative = UShortArray(*pRows)
+	pColsNative = UShortArray(*pCols)
+	err_code = _sdk.CameraRemoveDeadPixels(hCamera, pRowsNative, pColsNative, NumPixel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraRemoveAllDeadPixels(hCamera):
+	err_code = _sdk.CameraRemoveAllDeadPixels(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSaveDeadPixels(hCamera):
+	err_code = _sdk.CameraSaveDeadPixels(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSaveDeadPixelsToFile(hCamera, sFileName):
+	err_code = _sdk.CameraSaveDeadPixelsToFile(hCamera, _str_to_string_buffer(sFileName))
+	SetLastError(err_code)
+	return err_code
+
+def CameraLoadDeadPixelsFromFile(hCamera, sFileName):
+	err_code = _sdk.CameraLoadDeadPixelsFromFile(hCamera, _str_to_string_buffer(sFileName))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetImageBufferPriority(hCamera, wTimes, Priority):
+	pFrameInfo = tSdkFrameHead()
+	pbyBuffer = c_void_p()
+	err_code = _sdk.CameraGetImageBufferPriority(hCamera, byref(pFrameInfo), byref(pbyBuffer), wTimes, Priority)
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return (pbyBuffer.value, pFrameInfo)
+
+def CameraGetImageBufferPriorityEx(hCamera, wTimes, Priority):
+	_sdk.CameraGetImageBufferPriorityEx.restype = c_void_p
+	piWidth = c_int()
+	piHeight = c_int()
+	pFrameBuffer = _sdk.CameraGetImageBufferPriorityEx(hCamera, byref(piWidth), byref(piHeight), wTimes, Priority)
+	err_code = CAMERA_STATUS_SUCCESS if pFrameBuffer else CAMERA_STATUS_TIME_OUT
+	SetLastError(err_code)
+	if pFrameBuffer:
+		return (pFrameBuffer, piWidth.value, piHeight.value)
+	else:
+		raise CameraException(err_code)
+
+def CameraGetImageBufferPriorityEx2(hCamera, pImageData, uOutFormat, wTimes, Priority):
+	piWidth = c_int()
+	piHeight = c_int()
+	err_code = _sdk.CameraGetImageBufferPriorityEx2(hCamera, c_void_p(pImageData), uOutFormat, byref(piWidth), byref(piHeight), wTimes, Priority)
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return (piWidth.value, piHeight.value)
+
+def CameraGetImageBufferPriorityEx3(hCamera, pImageData, uOutFormat, wTimes, Priority):
+	piWidth = c_int()
+	piHeight = c_int()
+	puTimeStamp = c_uint()
+	err_code = _sdk.CameraGetImageBufferPriorityEx3(hCamera, c_void_p(pImageData), uOutFormat, byref(piWidth), byref(piHeight), byref(puTimeStamp), wTimes, Priority)
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return (piWidth.value, piHeight.value, puTimeStamp.value)
+
+def CameraClearBuffer(hCamera):
+	err_code = _sdk.CameraClearBuffer(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSoftTriggerEx(hCamera, uFlags):
+	err_code = _sdk.CameraSoftTriggerEx(hCamera, uFlags)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetHDR(hCamera, value):
+	err_code = _sdk.CameraSetHDR(hCamera, value)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetHDR(hCamera):
+	value = c_int()
+	err_code = _sdk.CameraGetHDR(hCamera, byref(value))
+	SetLastError(err_code)
+	return value.value
+
+def CameraGetFrameID(hCamera):
+	FrameID = c_uint()
+	err_code = _sdk.CameraGetFrameID(hCamera, byref(FrameID))
+	SetLastError(err_code)
+	return FrameID.value
+
+def CameraGetFrameTimeStamp(hCamera):
+	TimeStamp = c_uint64()
+	TimeStampL = c_uint32.from_buffer(TimeStamp)
+	TimeStampH = c_uint32.from_buffer(TimeStamp, 4)
+	err_code = _sdk.CameraGetFrameTimeStamp(hCamera, byref(TimeStampL), byref(TimeStampH))
+	SetLastError(err_code)
+	return TimeStamp.value
+
+def CameraSetHDRGainMode(hCamera, value):
+	err_code = _sdk.CameraSetHDRGainMode(hCamera, value)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetHDRGainMode(hCamera):
+	value = c_int()
+	err_code = _sdk.CameraGetHDRGainMode(hCamera, byref(value))
+	SetLastError(err_code)
+	return value.value
+
+def CameraCreateDIBitmap(hDC, pFrameBuffer, pFrameHead):
+	outBitmap = c_void_p()
+	err_code = _sdk.CameraCreateDIBitmap(hDC, c_void_p(pFrameBuffer), byref(pFrameHead), byref(outBitmap))
+	SetLastError(err_code)
+	return outBitmap.value
+
+def CameraDrawFrameBuffer(pFrameBuffer, pFrameHead, hWnd, Algorithm, Mode):
+	err_code = _sdk.CameraDrawFrameBuffer(c_void_p(pFrameBuffer), byref(pFrameHead), c_void_p(hWnd), Algorithm, Mode)
+	SetLastError(err_code)
+	return err_code
+
+def CameraFlipFrameBuffer(pFrameBuffer, pFrameHead, Flags):
+	err_code = _sdk.CameraFlipFrameBuffer(c_void_p(pFrameBuffer), byref(pFrameHead), Flags)
+	SetLastError(err_code)
+	return err_code
+
+def CameraConvertFrameBufferFormat(hCamera, pInFrameBuffer, pOutFrameBuffer, outWidth, outHeight, outMediaType, pFrameHead):
+	err_code = _sdk.CameraConvertFrameBufferFormat(hCamera, c_void_p(pInFrameBuffer), c_void_p(pOutFrameBuffer), outWidth, outHeight, outMediaType, byref(pFrameHead))
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetConnectionStatusCallback(hCamera, pCallBack, pContext = 0):
+	err_code = _sdk.CameraSetConnectionStatusCallback(hCamera, pCallBack, c_void_p(pContext) )
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetLightingControllerMode(hCamera, index, mode):
+	err_code = _sdk.CameraSetLightingControllerMode(hCamera, index, mode)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetLightingControllerState(hCamera, index, state):
+	err_code = _sdk.CameraSetLightingControllerState(hCamera, index, state)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetFrameResendCount(hCamera, count):
+	err_code = _sdk.CameraSetFrameResendCount(hCamera, count)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetUndistortParams(hCamera, width, height, cameraMatrix, distCoeffs):
+	assert(len(cameraMatrix) == 4)
+	assert(len(distCoeffs) == 5)
+	cameraMatrixNative = (c_double * len(cameraMatrix))(*cameraMatrix)
+	distCoeffsNative = (c_double * len(distCoeffs))(*distCoeffs)
+	err_code = _sdk.CameraSetUndistortParams(hCamera, width, height, cameraMatrixNative, distCoeffsNative)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetUndistortParams(hCamera):
+	width = c_int()
+	height = c_int()
+	cameraMatrix = (c_double * 4)()
+	distCoeffs = (c_double * 5)()
+	err_code = _sdk.CameraGetUndistortParams(hCamera, byref(width), byref(height), cameraMatrix, distCoeffs)
+	SetLastError(err_code)
+	width, height = width.value, height.value
+	cameraMatrix = cameraMatrix[:]
+	distCoeffs = distCoeffs[:]
+	return (width, height, cameraMatrix, distCoeffs)
+
+def CameraSetUndistortEnable(hCamera, bEnable):
+	err_code = _sdk.CameraSetUndistortEnable(hCamera, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetUndistortEnable(hCamera):
+	value = c_int()
+	err_code = _sdk.CameraGetUndistortEnable(hCamera, byref(value))
+	SetLastError(err_code)
+	return value.value
+
+def CameraCustomizeUndistort(hCamera, hParent):
+	err_code = _sdk.CameraCustomizeUndistort(hCamera, hParent)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetEyeCount(hCamera):
+	EyeCount = c_int()
+	err_code = _sdk.CameraGetEyeCount(hCamera, byref(EyeCount))
+	SetLastError(err_code)
+	return EyeCount.value
+
+def CameraMultiEyeImageProcess(hCamera, iEyeIndex, pbyIn, pInFrInfo, pbyOut, pOutFrInfo, uOutFormat, uReserved):
+	err_code = _sdk.CameraMultiEyeImageProcess(hCamera, iEyeIndex, c_void_p(pbyIn), byref(pInFrInfo), c_void_p(pbyOut), byref(pOutFrInfo), uOutFormat, uReserved)
+	SetLastError(err_code)
+	return err_code
+
+# CameraGrabber
+
+def CameraGrabber_CreateFromDevicePage():
+	Grabber = c_void_p()
+	err_code = _sdk.CameraGrabber_CreateFromDevicePage(byref(Grabber))
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return Grabber.value
+
+def CameraGrabber_CreateByIndex(Index):
+	Grabber = c_void_p()
+	err_code = _sdk.CameraGrabber_CreateByIndex(byref(Grabber), Index)
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return Grabber.value
+
+def CameraGrabber_CreateByName(Name):
+	Grabber = c_void_p()
+	err_code = _sdk.CameraGrabber_CreateByName(byref(Grabber), _str_to_string_buffer(Name))
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return Grabber.value
+
+def CameraGrabber_Create(pDevInfo):
+	Grabber = c_void_p()
+	err_code = _sdk.CameraGrabber_Create(byref(Grabber), byref(pDevInfo))
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return Grabber.value
+
+def CameraGrabber_Destroy(Grabber):
+	err_code = _sdk.CameraGrabber_Destroy(c_void_p(Grabber))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_SetHWnd(Grabber, hWnd):
+	err_code = _sdk.CameraGrabber_SetHWnd(c_void_p(Grabber), c_void_p(hWnd) )
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_SetPriority(Grabber, Priority):
+	err_code = _sdk.CameraGrabber_SetPriority(c_void_p(Grabber), Priority)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_StartLive(Grabber):
+	err_code = _sdk.CameraGrabber_StartLive(c_void_p(Grabber))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_StopLive(Grabber):
+	err_code = _sdk.CameraGrabber_StopLive(c_void_p(Grabber))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_SaveImage(Grabber, TimeOut):
+	Image = c_void_p()
+	err_code = _sdk.CameraGrabber_SaveImage(c_void_p(Grabber), byref(Image), TimeOut)
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return Image.value
+
+def CameraGrabber_SaveImageAsync(Grabber):
+	err_code = _sdk.CameraGrabber_SaveImageAsync(c_void_p(Grabber))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_SaveImageAsyncEx(Grabber, UserData):
+	err_code = _sdk.CameraGrabber_SaveImageAsyncEx(c_void_p(Grabber), c_void_p(UserData))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_SetSaveImageCompleteCallback(Grabber, Callback, Context = 0):
+	err_code = _sdk.CameraGrabber_SetSaveImageCompleteCallback(c_void_p(Grabber), Callback, c_void_p(Context))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_SetFrameListener(Grabber, Listener, Context = 0):
+	err_code = _sdk.CameraGrabber_SetFrameListener(c_void_p(Grabber), Listener, c_void_p(Context))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_SetRawCallback(Grabber, Callback, Context = 0):
+	err_code = _sdk.CameraGrabber_SetRawCallback(c_void_p(Grabber), Callback, c_void_p(Context))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_SetRGBCallback(Grabber, Callback, Context = 0):
+	err_code = _sdk.CameraGrabber_SetRGBCallback(c_void_p(Grabber), Callback, c_void_p(Context))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_GetCameraHandle(Grabber):
+	hCamera = c_int()
+	err_code = _sdk.CameraGrabber_GetCameraHandle(c_void_p(Grabber), byref(hCamera))
+	SetLastError(err_code)
+	return hCamera.value
+
+def CameraGrabber_GetStat(Grabber):
+	stat = tSdkGrabberStat()
+	err_code = _sdk.CameraGrabber_GetStat(c_void_p(Grabber), byref(stat))
+	SetLastError(err_code)
+	return stat
+
+def CameraGrabber_GetCameraDevInfo(Grabber):
+	DevInfo = tSdkCameraDevInfo()
+	err_code = _sdk.CameraGrabber_GetCameraDevInfo(c_void_p(Grabber), byref(DevInfo))
+	SetLastError(err_code)
+	return DevInfo
+
+# CameraImage
+
+def CameraImage_Create(pFrameBuffer, pFrameHead, bCopy):
+	Image = c_void_p()
+	err_code = _sdk.CameraImage_Create(byref(Image), c_void_p(pFrameBuffer), byref(pFrameHead), bCopy)
+	SetLastError(err_code)
+	return Image.value
+
+def CameraImage_CreateEmpty():
+	Image = c_void_p()
+	err_code = _sdk.CameraImage_CreateEmpty(byref(Image))
+	SetLastError(err_code)
+	return Image.value
+
+def CameraImage_Destroy(Image):
+	err_code = _sdk.CameraImage_Destroy(c_void_p(Image))
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_GetData(Image):
+	DataBuffer = c_void_p()
+	HeadPtr = c_void_p()
+	err_code = _sdk.CameraImage_GetData(c_void_p(Image), byref(DataBuffer), byref(HeadPtr))
+	SetLastError(err_code)
+	if err_code == 0:
+		return (DataBuffer.value, tSdkFrameHead.from_address(HeadPtr.value) )
+	else:
+		return (0, None)
+
+def CameraImage_GetUserData(Image):
+	UserData = c_void_p()
+	err_code = _sdk.CameraImage_GetUserData(c_void_p(Image), byref(UserData))
+	SetLastError(err_code)
+	return UserData.value
+
+def CameraImage_SetUserData(Image, UserData):
+	err_code = _sdk.CameraImage_SetUserData(c_void_p(Image), c_void_p(UserData))
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_IsEmpty(Image):
+	IsEmpty = c_int()
+	err_code = _sdk.CameraImage_IsEmpty(c_void_p(Image), byref(IsEmpty))
+	SetLastError(err_code)
+	return IsEmpty.value
+
+def CameraImage_Draw(Image, hWnd, Algorithm):
+	err_code = _sdk.CameraImage_Draw(c_void_p(Image), c_void_p(hWnd), Algorithm)
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_DrawFit(Image, hWnd, Algorithm):
+	err_code = _sdk.CameraImage_DrawFit(c_void_p(Image), c_void_p(hWnd), Algorithm)
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_DrawToDC(Image, hDC, Algorithm, xDst, yDst, cxDst, cyDst):
+	err_code = _sdk.CameraImage_DrawToDC(c_void_p(Image), c_void_p(hDC), Algorithm, xDst, yDst, cxDst, cyDst)
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_DrawToDCFit(Image, hDC, Algorithm, xDst, yDst, cxDst, cyDst):
+	err_code = _sdk.CameraImage_DrawToDCFit(c_void_p(Image), c_void_p(hDC), Algorithm, xDst, yDst, cxDst, cyDst)
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_BitBlt(Image, hWnd, xDst, yDst, cxDst, cyDst, xSrc, ySrc):
+	err_code = _sdk.CameraImage_BitBlt(c_void_p(Image), c_void_p(hWnd), xDst, yDst, cxDst, cyDst, xSrc, ySrc)
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_BitBltToDC(Image, hDC, xDst, yDst, cxDst, cyDst, xSrc, ySrc):
+	err_code = _sdk.CameraImage_BitBltToDC(c_void_p(Image), c_void_p(hDC), xDst, yDst, cxDst, cyDst, xSrc, ySrc)
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_SaveAsBmp(Image, FileName):
+	err_code = _sdk.CameraImage_SaveAsBmp(c_void_p(Image), _str_to_string_buffer(FileName))
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_SaveAsJpeg(Image, FileName, Quality):
+	err_code = _sdk.CameraImage_SaveAsJpeg(c_void_p(Image), _str_to_string_buffer(FileName), Quality)
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_SaveAsPng(Image, FileName):
+	err_code = _sdk.CameraImage_SaveAsPng(c_void_p(Image), _str_to_string_buffer(FileName))
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_SaveAsRaw(Image, FileName, Format):
+	err_code = _sdk.CameraImage_SaveAsRaw(c_void_p(Image), _str_to_string_buffer(FileName), Format)
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_IPicture(Image):
+	NewPic = c_void_p()
+	err_code = _sdk.CameraImage_IPicture(c_void_p(Image), byref(NewPic))
+	SetLastError(err_code)
+	return NewPic.value


### PR DESCRIPTION
## Summary

Adds a new `dual_fanuc` ROS2 package on top of `v1.1`'s EtherNet/IP driver and action servers. The package implements a two-robot coordinated dice manipulation task: Robot 1 picks a die from a bin, scans it under an overhead MindVision GigE camera, orients a target pip to the top via rotation primitives, and hands it to Robot 2 over a back-and-forth conveyor pair. The two robots iterate through pips 1–6 and end the run with the final die placed at a fixed termination pose.

**Pure addition — no existing upstream files are modified.**

## What's added

### `src/dual_fanuc/` (new ROS2 package)
- `robot1.py` / `robot2.py` — orchestration nodes for each robot, communicating via `/dual_fanuc/robot{1,2}_dice_location` topics.
- `pip_lookup.py` — shared `(target_pip, scan_top, scan_after_xflip) → rotation-action` tables (one table per target pip 1–6).
- `mv_camera_node.py` — ROS2 wrapper around the MindVision SDK. Publishes `/mv_camera/image_raw` and exposes `/mv_camera/capture` for synchronous frame triggers. Picks the routable host NIC when multiple interfaces reach the camera.
- HSV + HoughCircles pip detector inside `_crop_die` / `_count_pips` (ROI → HSV mask → contour fill → bitwise-and → bounding-box crop → grayscale + GaussianBlur → HoughCircles). Identical pipeline at calibration time and runtime.

### `scripts/` (calibration & one-shot utilities)
- `calibrate_hsv.py` / `calibrate_hough.py` — interactive trackbar UIs that write tuned values back into both robot files.
- `grab.py` / `grab_sdk.py` — single-frame capture (via ROS camera node or directly via the SDK).
- `test_conveyor.py` / `test_gripper.py` — bench utilities.

### Tooling
- `justfile` — one-line recipes: `build`, `launch[1|2]`, `run[2]`, `rotate[1|2]`, `calibrate-hsv`, `calibrate-hough`, gripper toggles, conveyors, `kill`.
- `requirements.txt` — `pycomm3`, `opencv-python`, `evdev`, `pynput`, `numpy<2` (the pin matches Jazzy `cv_bridge`'s NumPy 1.x ABI).
- `.env.example` — `ROBOT_*_NAME` / `ROBOT_*_IP` placeholders.
- `third_party/mvsdk.py` — vendored MindVision Python bindings, installed into a venv by `just setup`.

## Assumptions

- Standard die chirality: opposite faces sum to 7; with 1 on top and 2 facing the viewer, 3 is on the right.
- Die enters the system at a known `DICE_PICK` pose for Robot 1 and ends at a fixed `DICE_END` after pip 6.
- Robot 1 has a Schunk gripper, Robot 2 has an OnRobot gripper (action server already in upstream).

## Test plan

- [ ] `colcon build` succeeds against the merged tree on ROS2 Jazzy.
- [ ] `just launch` brings up both robot stacks + the camera node without error.
- [ ] `just rotate1` runs all five Robot 1 rotation primitives without the camera.
- [ ] `just rotate2` runs all five Robot 2 rotation primitives without the other robot.
- [ ] Full pipeline (`just run` + `just run2`) places one die per pip 1–6 with pre-placement camera verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)