### PR TITLE
Sequential dice-game package + driver improvements (kate)

### DIFF
--- a/src/action_servers/action_servers/joint_pose_server.py
+++ b/src/action_servers/action_servers/joint_pose_server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import sys
 import os
+import time
 import rclpy
 
 import dependencies.FANUCethernetipDriver as FANUCethernetipDriver
@@ -27,6 +28,7 @@ class joint_pose_server(Node):
 
         self.goal = JointPose.Goal()
         self.bot = robot(self.get_parameter('robot_ip').value)
+        self.bot.set_speed(300)  # reset to full speed on startup
 
         self._action_server = ActionServer(self, JointPose, f"{self.get_parameter('robot_name').value}/joint_pose", 
                                         execute_callback = self.execute_callback, 
@@ -38,27 +40,27 @@ class joint_pose_server(Node):
         self.goal = goal_request 
         # FIX!! This is ugly.. Put into a list.any()? Switch is also faster
         # Check that it recieved a valid goal
-        if self.goal.joint1 > 179.9 or self.goal.joint1 < -179.9:
+        if self.goal.joint1 > 270.0 or self.goal.joint1 < -270.0:
             self.get_logger().info('Invalid request')
             return GoalResponse.REJECT
         
-        elif self.goal.joint2 > 179.9 or self.goal.joint2 < -179.9:
+        elif self.goal.joint2 > 270.0 or self.goal.joint2 < -270.0:
             self.get_logger().info('Invalid request')
             return GoalResponse.REJECT
         
-        elif self.goal.joint3 > 179.9 or self.goal.joint3 < -179.9:
+        elif self.goal.joint3 > 270.0 or self.goal.joint3 < -270.0:
             self.get_logger().info('Invalid request')
             return GoalResponse.REJECT
         
-        elif self.goal.joint4 > 179.9 or self.goal.joint4 < -179.9:
+        elif self.goal.joint4 > 270.0 or self.goal.joint4 < -270.0:
             self.get_logger().info('Invalid request')
             return GoalResponse.REJECT
         
-        elif self.goal.joint5 > 179.9 or self.goal.joint5 < -179.9:
+        elif self.goal.joint5 > 270.0 or self.goal.joint5 < -270.0:
             self.get_logger().info('Invalid request')
             return GoalResponse.REJECT
         
-        elif self.goal.joint6 > 179.9 or self.goal.joint6 < -179.9:
+        elif self.goal.joint6 > 270.0 or self.goal.joint6 < -270.0:
             self.get_logger().info('Invalid request')
             return GoalResponse.REJECT
         else:
@@ -83,11 +85,20 @@ class joint_pose_server(Node):
             list = [self.goal.joint1,
                     self.goal.joint2,
                     self.goal.joint3,
-                    self.goal.joint4, 
+                    self.goal.joint4,
                     self.goal.joint5,
                     self.goal.joint6]
-            
+
+            if self.goal.speed > 0:
+                self.bot.set_speed(min(self.goal.speed, 300))
+            else:
+                self.bot.set_speed(300)
+
             self.bot.write_joint_pose(list, blocking=False)
+
+            # Give the robot controller time to set the moving flag before polling.
+            # Without this, is_moving() can return False before motion starts.
+            time.sleep(0.3)
 
             while self.bot.is_moving():
                 # Calculate distance left
@@ -100,6 +111,20 @@ class joint_pose_server(Node):
                 goal_handle.publish_feedback(feedback_msg) # Send value
 
                 feedback_msg.distance_left = self.bot.read_current_joint_position() # Update cur pos
+
+            # Verify robot has reached target before returning result.
+            # is_moving() can return False before the robot settles, so poll
+            # joint positions until all joints are within tolerance.
+            TOLERANCE_DEG = 2.0
+            deadline = time.time() + 30.0
+            while True:
+                current = self.bot.read_current_joint_position()
+                if all(abs(current[i] - list[i]) < TOLERANCE_DEG for i in range(6)):
+                    break
+                if time.time() > deadline:
+                    self.get_logger().warn('Position verification timed out — proceeding anyway')
+                    break
+                time.sleep(0.1)
 
             goal_handle.succeed()
             result = JointPose.Result()

--- a/src/action_servers/action_servers/onrobot_server.py
+++ b/src/action_servers/action_servers/onrobot_server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import sys
 import os
+import asyncio
 import rclpy
 
 import dependencies.FANUCethernetipDriver as FANUCethernetipDriver
@@ -61,7 +62,12 @@ class onrobot_gripper_server(Node):
     async def execute_callback(self, goal_handle):
         # WIP: Add Try/Except to catch possible error
         self.bot.onRobot_gripper(self.goal.width, self.goal.force)
-        
+
+        # Wait for gripper to reach target position.
+        # The OnRobot gripper has no hardware-feedback register to poll,
+        # so we gate on time before returning the result.
+        await asyncio.sleep(2.0)
+
         goal_handle.succeed()
         result = OnRobotGripper.Result()
         result.success = True

--- a/src/action_servers/action_servers/schunk_server.py
+++ b/src/action_servers/action_servers/schunk_server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import sys
 import os
+import asyncio
 import rclpy
 
 
@@ -59,6 +60,9 @@ class schunk_gripper_server(Node):
     async def execute_callback(self, goal_handle):
         # WIP: Add Try/Except to catch possible error
         self.bot.schunk_gripper(self.goal.command)
+
+        # Wait for gripper to actuate before returning result
+        await asyncio.sleep(2.0)
 
         goal_handle.succeed()
         result = SchunkGripper.Result()

--- a/src/action_servers/dependencies/robot_controller.py
+++ b/src/action_servers/dependencies/robot_controller.py
@@ -20,6 +20,7 @@
 
 # Imports
 import math
+import time
 import typing
 from . import FANUCethernetipDriver
 
@@ -251,6 +252,7 @@ class robot:
         """! checks to see if robot is moving based on the value of the sync register 1=moving 0=not moving
         """
         pose1 = self.read_current_cartesian_pose()
+        time.sleep(0.1)   # allow enough time between samples to detect motion
         pose2 = self.read_current_cartesian_pose()
         diff = list(map(lambda a, b: a - b, pose1, pose2))
         #print("Difference: ", diff)

--- a/src/dice_game/dice_game/bill_control.py
+++ b/src/dice_game/dice_game/bill_control.py
@@ -1,0 +1,533 @@
+#!/usr/bin/env python3
+"""
+bill_control.py
+
+Master control node for BILL (Robot 2, RIGHT, IP: 10.8.4.6).
+BILL is responsible for pips 2, 4, and 6.
+
+Conveyor assignment:
+  BILL controls the FRONT (closest) conveyor.
+  Even pips → front conveyor (BILL runs it directly).
+  Odd pips  → back conveyor  (DJ runs it — BILL just receives).
+
+State machine:
+  WAIT_FOR_DICE   → idle until DJ delivers die and calls /BILL/request_handoff
+  RECEIVE         → pick up from DJ's back conveyor end
+  PRESENT_COUNT   → present to camera, loop until expected pip found
+  SEND_TO_DJ      → place on front conveyor, run until delivered, signal DJ
+  loop for pips 2, 4, 6 — DJ places pip 6 at start position to end game
+"""
+
+import sys
+import time
+import threading
+
+import cv2
+import numpy as np
+
+import rclpy
+from rclpy.node import Node
+from rclpy.action import ActionClient
+from rclpy.callback_groups import ReentrantCallbackGroup, MutuallyExclusiveCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
+
+from fanuc_interfaces.action import JointPose, OnRobotGripper, Conveyor
+from fanuc_interfaces.srv import RequestHandoff
+from fanuc_interfaces.msg import DiceState, ProxReadings
+
+sys.path.insert(0, 'src/dice_game/dice_game')
+import mvsdk
+
+# ============================================================
+# JOINT POSITIONS  — all values in degrees, [J1, J2, J3, J4, J5, J6]
+# ============================================================
+JOINTS = {
+    # ── General ──────────────────────────────────────────────────────────
+    'home':                       [0.0,      0.0,    0.0,    0.0,   -90.0,  -45.0],
+
+    # ── Pick from DJ's back conveyor ─────────────────────────────────────
+    'pre_pick_dj_conveyor':       [-112.73,  25.87,  -7.33,  0.01,  -82.68, -22.83],
+    'pick_dj_conveyor':           [-112.73,  29.14, -22.28, -0.01,  -67.72, -22.83],
+
+    # ── Waypoint between DJ conveyor and BILL's set-on-conveyor area ─────
+    'intermediate_bill_conveyor': [-86.88,   27.74,   6.81,  0.36,  -97.26, -44.93],
+
+    # ── Dice imaging — normal horizontal grip ────────────────────────────
+    'cam_pickup':                 [-51.39,   45.68, -24.74, -0.256, -65.65, -80.36],
+    'cam_pickup_up':              [-51.39,   42.42, -15.89, -0.242, -74.5,  -80.36],
+
+    # ── Dice imaging — twist grip (vertical) ─────────────────────────────
+    'cam_pickup_twist':           [-49.68,   44.85, -25.84, -0.41,  -64.43,   4.71],
+    'cam_pickup_twist_up':        [-49.68,   41.86, -18.16,  0.386, -72.1,    4.77],
+
+    # ── Camera presentation ───────────────────────────────────────────────
+    'cam_present':                [-78.68,   24.16, -42.14, 162.96, -43.58, -207.59],
+
+    # ── Set die down on table ─────────────────────────────────────────────
+    'setdown':                    [-49.74,   54.33, -92.74, 139.64, -92.23, -223.70],
+    'setdown_up':                 [-49.64,   38.44, -78.20, 138.99, -81.18, -214.21],
+
+    # ── BILL's front conveyor (send back to DJ) ───────────────────────────
+    'pre_set_on_conveyor':        [-89.51,   18.89, -12.84,  1.14,  -75.99, -48.22],
+    'set_on_conveyor':            [-89.51,   22.82, -27.22,  1.25,  -61.61, -48.54],
+}
+
+# OnRobot gripper parameters
+GRIPPER_OPEN_WIDTH  = 100   # mm
+GRIPPER_CLOSE_WIDTH = 35    # mm
+GRIPPER_FORCE       = 40    # N
+
+# Proximity sensors for BILL's front conveyor
+FRONT_CONVEYOR_START_SENSOR = 'right'   # near BILL's drop end
+FRONT_CONVEYOR_STOP_SENSOR  = 'left'    # far end (DJ's side)
+
+# Sensor that trips when die arrives from DJ's back conveyor
+BACK_CONVEYOR_ARRIVE_SENSOR = 'right'   # TODO: confirm
+
+PROX_TIMEOUT          = 15.0
+MOTION_COMPLETE_TIMEOUT = 60.0
+
+BILL_IP   = '10.8.4.6'
+BILL_NAME = 'BILL'
+
+
+class BillControl(Node):
+    def __init__(self):
+        super().__init__('bill_control')
+
+        # Callback groups
+        self._action_cb = ReentrantCallbackGroup()
+        self._state_cb  = MutuallyExclusiveCallbackGroup()
+
+        # --- Action clients ---
+        self._joint_client   = ActionClient(self, JointPose,      'BILL/joint_pose',
+                                            callback_group=self._action_cb)
+        self._onrobot_client = ActionClient(self, OnRobotGripper, 'BILL/onrobot_gripper',
+                                            callback_group=self._action_cb)
+        self._convey_client  = ActionClient(self, Conveyor,        'BILL/conveyor',
+                                            callback_group=self._action_cb)
+
+        # --- Service clients ---
+        self._dj_handoff_cli = self.create_client(RequestHandoff, '/DJ/request_handoff',
+                                                   callback_group=self._action_cb)
+
+        # --- Handoff service server (DJ calls this to send dice to BILL) ---
+        self._handoff_server = self.create_service(
+            RequestHandoff, '/BILL/request_handoff',
+            self._handle_handoff,
+            callback_group=self._action_cb,
+        )
+
+        # --- State publisher ---
+        self._state_pub = self.create_publisher(DiceState, '/dice_state', 10)
+
+        # --- Internal state ---
+        self._bill_retries = 0
+        self._dj_retries   = 0
+        self._expected_pip = 2
+        self._last_prox    = {'right': 0, 'left': 0}
+        self._handoff_received = threading.Event()
+        self._annotated    = None
+
+        self.get_logger().info('BILL control node ready.')
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+    def _wait(self, future, timeout: float = 30.0):
+        deadline = time.time() + timeout
+        while not future.done():
+            if time.time() > deadline:
+                raise TimeoutError(f'Future timed out after {timeout}s')
+            time.sleep(0.02)
+        return future.result()
+
+    # ------------------------------------------------------------------
+    # Robot primitives
+    # ------------------------------------------------------------------
+    def _move(self, joints: list, speed: int = 0):
+        self.get_logger().info(f'Move → {joints}' + (f' @ {speed}mm/s' if speed else ''))
+        goal = JointPose.Goal()
+        goal.joint1, goal.joint2, goal.joint3 = joints[0], joints[1], joints[2]
+        goal.joint4, goal.joint5, goal.joint6 = joints[3], joints[4], joints[5]
+        goal.speed = speed
+        self._joint_client.wait_for_server()
+        gh = self._wait(self._joint_client.send_goal_async(goal))
+        if not gh.accepted:
+            raise RuntimeError('Joint move goal rejected')
+        self._wait(gh.get_result_async(), timeout=MOTION_COMPLETE_TIMEOUT)
+
+    def _gripper(self, width: int):
+        goal = OnRobotGripper.Goal()
+        goal.width = width
+        goal.force = GRIPPER_FORCE
+        self._onrobot_client.wait_for_server()
+        gh = self._wait(self._onrobot_client.send_goal_async(goal))
+        if not gh.accepted:
+            raise RuntimeError(f'Gripper goal rejected')
+        self._wait(gh.get_result_async())
+        state = 'OPEN' if width >= GRIPPER_OPEN_WIDTH else 'CLOSE'
+        self.get_logger().info(f'Gripper {state}')
+        time.sleep(2.0)
+
+    def _conveyor(self, command: str):
+        goal = Conveyor.Goal()
+        goal.command = command
+        self._convey_client.wait_for_server()
+        gh = self._wait(self._convey_client.send_goal_async(goal))
+        if not gh.accepted:
+            raise RuntimeError(f'Conveyor goal rejected: {command}')
+        self._wait(gh.get_result_async())
+
+    def _wait_for_prox_trip(self, side: str, timeout: float = PROX_TIMEOUT):
+        deadline = time.time() + timeout
+        self.get_logger().info(f'  Waiting for {side} sensor to trip...')
+        while self._last_prox.get(side, 0) == 0:
+            if time.time() > deadline:
+                raise TimeoutError(f'{side} sensor never tripped (timeout {timeout}s)')
+            time.sleep(0.05)
+        self.get_logger().info(f'  {side} sensor tripped.')
+
+    def _run_conveyor_sensors(self, start_sensor: str, stop_sensor: str):
+        self.get_logger().info('Waiting for die to load (start sensor)...')
+        self._wait_for_prox_trip(start_sensor, timeout=20.0)
+        self._conveyor('reverse')
+        self.get_logger().info('Conveyor running — waiting for die to arrive (stop sensor)...')
+        try:
+            self._wait_for_prox_trip(stop_sensor, timeout=20.0)
+            self.get_logger().info('Stop sensor tripped — running 2 more seconds...')
+            time.sleep(2.0)
+        finally:
+            self._conveyor('stop')
+        self.get_logger().info('Conveyor stopped — die delivered.')
+
+    # ------------------------------------------------------------------
+    # Camera
+    # ------------------------------------------------------------------
+    def _capture_image(self) -> np.ndarray:
+        devs = mvsdk.CameraEnumerateDevice()
+        if len(devs) < 1:
+            raise RuntimeError('No MindVision camera found. Check ethernet cable.')
+
+        hCamera = None
+        for attempt in range(5):
+            try:
+                hCamera = mvsdk.CameraInit(devs[0], -1, -1)
+                break
+            except Exception as e:
+                self.get_logger().warn(f'CameraInit attempt {attempt+1} failed: {e}')
+                time.sleep(2.0)
+        if hCamera is None:
+            raise RuntimeError('CameraInit failed after 5 attempts')
+
+        cap = mvsdk.CameraGetCapability(hCamera)
+        mono = (cap.sIspCapacity.bMonoSensor != 0)
+        fmt = mvsdk.CAMERA_MEDIA_TYPE_MONO8 if mono else mvsdk.CAMERA_MEDIA_TYPE_BGR8
+        mvsdk.CameraSetIspOutFormat(hCamera, fmt)
+        mvsdk.CameraSetTriggerMode(hCamera, 0)
+        mvsdk.CameraSetAeState(hCamera, 0)
+        mvsdk.CameraSetExposureTime(hCamera, 30 * 1000)
+        mvsdk.CameraPlay(hCamera)
+
+        channels = 1 if mono else 3
+        buf_size = cap.sResolutionRange.iWidthMax * cap.sResolutionRange.iHeightMax * channels
+        pFrameBuffer = mvsdk.CameraAlignMalloc(buf_size, 16)
+        try:
+            pRawData, FrameHead = mvsdk.CameraGetImageBuffer(hCamera, 2000)
+            mvsdk.CameraImageProcess(hCamera, pRawData, pFrameBuffer, FrameHead)
+            mvsdk.CameraReleaseImageBuffer(hCamera, pRawData)
+            frame_data = (mvsdk.c_ubyte * FrameHead.uBytes).from_address(pFrameBuffer)
+            frame = np.frombuffer(frame_data, dtype=np.uint8).reshape(
+                (FrameHead.iHeight, FrameHead.iWidth, channels))
+            return frame.copy()
+        finally:
+            mvsdk.CameraUnInit(hCamera)
+            mvsdk.CameraAlignFree(pFrameBuffer)
+
+    def _count_pips(self, image: np.ndarray) -> int:
+        hsv = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
+        mask = cv2.inRange(hsv, np.array([15, 60, 40]), np.array([45, 255, 255]))
+        kernel = np.ones((5, 5), np.uint8)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel, iterations=2)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN,  kernel, iterations=1)
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        if not contours:
+            self.get_logger().warn('No yellow die detected in image')
+            self._annotated = image.copy()
+            return -1
+
+        x, y, w, h = cv2.boundingRect(max(contours, key=cv2.contourArea))
+        margin = 8
+        x = max(0, x - margin);  y = max(0, y - margin)
+        w = min(image.shape[1] - x, w + 2 * margin)
+        h = min(image.shape[0] - y, h + 2 * margin)
+
+        roi = image[y:y+h, x:x+w].copy()
+        roi_bright = cv2.convertScaleAbs(roi, alpha=3.5, beta=50)
+        gray = cv2.cvtColor(roi_bright, cv2.COLOR_BGR2GRAY)
+        blur = cv2.GaussianBlur(gray, (3, 3), 0)
+
+        _, dark_otsu = cv2.threshold(blur, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+        dark_adapt = cv2.adaptiveThreshold(
+            blur, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, cv2.THRESH_BINARY_INV, 21, 8)
+        dark = cv2.bitwise_or(dark_otsu, dark_adapt)
+        dark = cv2.morphologyEx(dark, cv2.MORPH_OPEN, np.ones((2, 2), np.uint8))
+
+        pip_contours, _ = cv2.findContours(dark, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        border_x = int(w * 0.12);  border_y = int(h * 0.12)
+        pip_count = 0
+        annotated = image.copy()
+        cv2.rectangle(annotated, (x, y), (x+w, y+h), (255, 0, 0), 2)
+
+        for c in pip_contours:
+            area = cv2.contourArea(c)
+            if area < 20 or area > 6000:
+                continue
+            perimeter = cv2.arcLength(c, True)
+            if perimeter == 0 or (4 * np.pi * area / (perimeter ** 2)) <= 0.55:
+                continue
+            M = cv2.moments(c)
+            if M['m00'] == 0:
+                continue
+            cx = int(M['m10'] / M['m00']) + x
+            cy = int(M['m01'] / M['m00']) + y
+            if (cx - x) < border_x or (cx - x) > w - border_x:
+                continue
+            if (cy - y) < border_y or (cy - y) > h - border_y:
+                continue
+            pip_count += 1
+            cv2.drawContours(annotated, [c + np.array([[[x, y]]])], -1, (0, 255, 0), 2)
+            cv2.circle(annotated, (cx, cy), 4, (0, 0, 255), -1)
+
+        cv2.putText(annotated, f'pips: {pip_count}', (10, 40),
+                    cv2.FONT_HERSHEY_SIMPLEX, 1.2, (0, 255, 0), 2)
+        self._annotated = annotated
+        return pip_count
+
+    def _capture_and_show(self, label: str, target: int = 0) -> int:
+        self.get_logger().info(f'Capturing ({label})...')
+        frame = self._capture_image()
+        count = self._count_pips(frame)
+        self.get_logger().info(f'Pip count: {count}')
+        cv2.imwrite('dice_capture.jpg', frame)
+        cv2.imwrite('dice_annotated.jpg', self._annotated)
+        return count
+
+    # ------------------------------------------------------------------
+    # Movement sub-routines (proven in bill_cam_test.py)
+    # ------------------------------------------------------------------
+    def _normal_pickup_present(self, label: str, target: int) -> int:
+        """Pick up from table (horizontal), present to camera. Still holding die."""
+        self._move(JOINTS['cam_pickup_up'], speed=300)
+        self._move(JOINTS['cam_pickup'])
+        self._gripper(GRIPPER_CLOSE_WIDTH)
+        self._move(JOINTS['cam_pickup_up'])
+        self._move(JOINTS['cam_present'], speed=50)
+        return self._capture_and_show(label, target)
+
+    def _twist_pickup_present(self, label: str, target: int) -> int:
+        """Pick up from table (twist/vertical), present to camera. Still holding die."""
+        self._move(JOINTS['cam_pickup_twist_up'], speed=300)
+        self._move(JOINTS['cam_pickup_twist'])
+        self._gripper(GRIPPER_CLOSE_WIDTH)
+        self._move(JOINTS['cam_pickup_twist_up'])
+        self._move(JOINTS['cam_pickup_up'])
+        self._move(JOINTS['cam_present'], speed=50)
+        return self._capture_and_show(label, target)
+
+    def _set_down(self):
+        """Set die back down on table from cam_present position."""
+        self._move(JOINTS['setdown_up'])
+        self._move(JOINTS['setdown'])
+        self._gripper(GRIPPER_OPEN_WIDTH)
+        self._move(JOINTS['setdown_up'])
+        self._bill_retries += 1
+
+    def _place_on_conveyor(self):
+        """Set die down normally, re-pick with twist grip, place on BILL's front conveyor."""
+        self._set_down()
+        self._move(JOINTS['cam_pickup_twist_up'], speed=300)
+        self._move(JOINTS['cam_pickup_twist'])
+        self._gripper(GRIPPER_CLOSE_WIDTH)
+        self._move(JOINTS['cam_pickup_twist_up'])
+        self._move(JOINTS['intermediate_bill_conveyor'])
+        self._move(JOINTS['pre_set_on_conveyor'])
+        self._move(JOINTS['set_on_conveyor'])
+        self._gripper(GRIPPER_OPEN_WIDTH)
+        self._move(JOINTS['pre_set_on_conveyor'])
+
+    # ------------------------------------------------------------------
+    # State
+    # ------------------------------------------------------------------
+    def _publish_state(self, robot_holding: str):
+        msg = DiceState()
+        msg.expected_pip  = self._expected_pip
+        msg.dj_retries    = self._dj_retries
+        msg.bill_retries  = self._bill_retries
+        msg.robot_holding = robot_holding
+        self._state_pub.publish(msg)
+
+    # ------------------------------------------------------------------
+    # Handoff service server (DJ calls this to send dice to BILL)
+    # ------------------------------------------------------------------
+    def _handle_handoff(self, request: RequestHandoff.Request,
+                        response: RequestHandoff.Response):
+        self.get_logger().info('Handoff request from DJ — moving to pre-pick position.')
+        self._move(JOINTS['home'])
+        self._gripper(GRIPPER_OPEN_WIDTH)
+        self._move(JOINTS['pre_pick_dj_conveyor'])
+        response.accepted = True
+        self._handoff_received.set()
+        return response
+
+    # ------------------------------------------------------------------
+    # State machine sub-steps
+    # ------------------------------------------------------------------
+    def _present_and_count(self, target: int):
+        """
+        Already holding die (just picked from DJ's conveyor, at pre_pick_dj_conveyor).
+        Route to cam_present, loop until target pip found. Returns holding die.
+        """
+        self.get_logger().info(f'=== BILL searching for pip {target} ===')
+        attempt = 0
+        twist_done = False
+        capture_num = 0
+
+        # First present: route through intermediate waypoint from DJ conveyor
+        capture_num += 1
+        self._move(JOINTS['intermediate_bill_conveyor'])
+        self._move(JOINTS['cam_present'], speed=50)
+        count = self._capture_and_show(f'dj_conveyor_{capture_num}', target)
+        self.get_logger().info(f'  Pip count: {count}  (need {target})')
+        self._publish_state('BILL')
+        if count == target:
+            self.get_logger().info(f'  Found pip {target} on first present!')
+            return
+        self._set_down()
+        attempt += 1
+
+        while True:
+            # After 3 failed normal attempts, do one twist if not already done
+            if attempt == 4 and not twist_done:
+                self.get_logger().info('3 normal attempts failed — trying twist grip')
+                capture_num += 1
+                count = self._twist_pickup_present(f'twist_{capture_num}', target)
+                self.get_logger().info(f'  Pip count: {count}  (need {target})')
+                self._publish_state('BILL')
+                if count == target:
+                    self.get_logger().info(f'  Found pip {target} on twist!')
+                    return
+                self._set_down()
+                twist_done = True
+
+            # Normal pickup
+            capture_num += 1
+            count = self._normal_pickup_present(f'normal_{capture_num}', target)
+            self.get_logger().info(f'  Pip count: {count}  (need {target})')
+            self._publish_state('BILL')
+            if count == target:
+                self.get_logger().info(f'  Found pip {target}!')
+                return
+            self._set_down()
+            attempt += 1
+
+    def _send_to_dj(self):
+        """
+        Already holding die at cam_present. Place on front conveyor, run belt until
+        delivered, then signal DJ to come pick up.
+        """
+        self.get_logger().info('Placing die on front conveyor...')
+        self._place_on_conveyor()
+        self._move(JOINTS['home'])
+
+        self._publish_state('IN_TRANSIT')
+        self._run_conveyor_sensors(FRONT_CONVEYOR_START_SENSOR, FRONT_CONVEYOR_STOP_SENSOR)
+
+        # Die is now at DJ's end — signal DJ to pick up
+        self.get_logger().info('Die delivered — signaling DJ to pick up...')
+        req = RequestHandoff.Request()
+        req.conveyor = 'front'
+        self._dj_handoff_cli.wait_for_service()
+        future = self._dj_handoff_cli.call_async(req)
+        resp = self._wait(future, timeout=30.0)
+        if not resp.accepted:
+            raise RuntimeError('DJ rejected handoff request')
+
+    # ------------------------------------------------------------------
+    # Main state machine
+    # ------------------------------------------------------------------
+    def run(self):
+        self.get_logger().info('=== BILL state machine starting — waiting for first handoff ===')
+
+        # Subscribe to prox readings
+        self.create_subscription(
+            ProxReadings, 'BILL/prox_readings',
+            lambda msg: self._last_prox.update({'right': msg.right, 'left': msg.left}),
+            10,
+        )
+
+        for expected in [2, 4, 6]:
+            self._expected_pip = expected
+            self.get_logger().info(f'--- BILL waiting to receive die (need pip {expected}) ---')
+
+            # Block until DJ calls our handoff service
+            # (_handle_handoff moves us to pre_pick_dj_conveyor and opens gripper)
+            self._handoff_received.clear()
+            self._handoff_received.wait()
+
+            # Die is already at pick position (DJ ran conveyor before calling handoff)
+
+            # Pick up die
+            self._move(JOINTS['pick_dj_conveyor'])
+            self._gripper(GRIPPER_CLOSE_WIDTH)
+            self._move(JOINTS['pre_pick_dj_conveyor'])
+            self.get_logger().info('Die picked up from DJ conveyor.')
+
+            # Search for target pip
+            self._present_and_count(expected)
+
+            # Send back to DJ (all pips including 6)
+            self.get_logger().info(f'--- BILL sending pip {expected} back to DJ ---')
+            self._send_to_dj()
+
+            if expected == 6:
+                self._publish_state('PLACED')
+                self.get_logger().info('=== BILL done. Game complete! ===')
+                self._print_results()
+                return
+
+        self.get_logger().error('Unexpected exit from run() loop.')
+
+    def _print_results(self):
+        total = self._dj_retries + self._bill_retries
+        self.get_logger().info('==============================')
+        self.get_logger().info('         FINAL RESULTS        ')
+        self.get_logger().info('==============================')
+        self.get_logger().info(f'  DJ   retries : {self._dj_retries}')
+        self.get_logger().info(f'  BILL retries : {self._bill_retries}')
+        self.get_logger().info(f'  Total retries: {total}')
+        self.get_logger().info('==============================')
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = BillControl()
+
+    executor = MultiThreadedExecutor(num_threads=4)
+    executor.add_node(node)
+
+    spin_thread = threading.Thread(target=executor.spin, daemon=True)
+    spin_thread.start()
+
+    try:
+        node.run()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        executor.shutdown()
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/dice_game/dice_game/camera_server.py
+++ b/src/dice_game/dice_game/camera_server.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+camera_server.py
+
+ROS2 service node that captures an image from the MindVision overhead camera,
+counts pips on the yellow die face, and returns the count as an int32.
+
+Service: /capture_and_count  (fanuc_interfaces/srv/CapturePip)
+
+Based on pip_counter.py from asn1 — uses dual-threshold (Otsu + adaptive)
+pip detection and retries CameraInit up to 5 times.
+"""
+
+import time
+import cv2
+import numpy as np
+
+import rclpy
+from rclpy.node import Node
+
+from fanuc_interfaces.srv import CapturePip
+from dice_game import mvsdk
+
+
+class CameraServer(Node):
+    def __init__(self):
+        super().__init__('camera_server')
+        self.srv = self.create_service(
+            CapturePip,
+            '/capture_and_count',
+            self._capture_callback,
+        )
+        self.get_logger().info('Camera server ready — /capture_and_count')
+
+    # ------------------------------------------------------------------
+    # Camera
+    # ------------------------------------------------------------------
+    def _capture_image(self) -> np.ndarray:
+        devs = mvsdk.CameraEnumerateDevice()
+        if len(devs) < 1:
+            raise RuntimeError('No MindVision camera found. Check ethernet cable.')
+
+        hCamera = None
+        last_err = None
+        for attempt in range(5):
+            try:
+                hCamera = mvsdk.CameraInit(devs[0], -1, -1)
+                break
+            except Exception as e:
+                last_err = e
+                self.get_logger().warn(
+                    f'CameraInit attempt {attempt + 1} failed: {e} — retrying in 2s')
+                time.sleep(2.0)
+        if hCamera is None:
+            raise RuntimeError(f'CameraInit failed after 5 attempts: {last_err}')
+
+        cap = mvsdk.CameraGetCapability(hCamera)
+        mono = (cap.sIspCapacity.bMonoSensor != 0)
+        fmt = mvsdk.CAMERA_MEDIA_TYPE_MONO8 if mono else mvsdk.CAMERA_MEDIA_TYPE_BGR8
+        mvsdk.CameraSetIspOutFormat(hCamera, fmt)
+        mvsdk.CameraSetTriggerMode(hCamera, 0)
+        mvsdk.CameraSetAeState(hCamera, 0)
+        mvsdk.CameraSetExposureTime(hCamera, 30 * 1000)
+        mvsdk.CameraPlay(hCamera)
+
+        channels = 1 if mono else 3
+        buf_size = cap.sResolutionRange.iWidthMax * cap.sResolutionRange.iHeightMax * channels
+        pFrameBuffer = mvsdk.CameraAlignMalloc(buf_size, 16)
+
+        try:
+            pRawData, FrameHead = mvsdk.CameraGetImageBuffer(hCamera, 2000)
+            mvsdk.CameraImageProcess(hCamera, pRawData, pFrameBuffer, FrameHead)
+            mvsdk.CameraReleaseImageBuffer(hCamera, pRawData)
+            frame_data = (mvsdk.c_ubyte * FrameHead.uBytes).from_address(pFrameBuffer)
+            frame = np.frombuffer(frame_data, dtype=np.uint8).reshape(
+                (FrameHead.iHeight, FrameHead.iWidth, channels)
+            )
+            return frame.copy()
+        finally:
+            mvsdk.CameraUnInit(hCamera)
+            mvsdk.CameraAlignFree(pFrameBuffer)
+
+    # ------------------------------------------------------------------
+    # Die detection
+    # ------------------------------------------------------------------
+    def _find_die_bbox(self, image: np.ndarray):
+        hsv = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
+        mask = cv2.inRange(hsv, np.array([15, 60, 40]), np.array([45, 255, 255]))
+        kernel = np.ones((5, 5), np.uint8)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel, iterations=2)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN,  kernel, iterations=1)
+
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        if not contours:
+            return None
+
+        x, y, w, h = cv2.boundingRect(max(contours, key=cv2.contourArea))
+        margin = 8
+        x = max(0, x - margin)
+        y = max(0, y - margin)
+        w = min(image.shape[1] - x, w + 2 * margin)
+        h = min(image.shape[0] - y, h + 2 * margin)
+        return (x, y, w, h)
+
+    # ------------------------------------------------------------------
+    # Pip counting — dual threshold (Otsu + adaptive), border exclusion
+    # ------------------------------------------------------------------
+    def _count_pips(self, image: np.ndarray, bbox: tuple) -> int:
+        x, y, w, h = bbox
+        roi = image[y:y+h, x:x+w].copy()
+
+        roi_bright = cv2.convertScaleAbs(roi, alpha=3.5, beta=50)
+        gray = cv2.cvtColor(roi_bright, cv2.COLOR_BGR2GRAY)
+        blur = cv2.GaussianBlur(gray, (3, 3), 0)
+
+        _, dark_otsu = cv2.threshold(blur, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+        dark_adapt = cv2.adaptiveThreshold(
+            blur, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, cv2.THRESH_BINARY_INV, 21, 8)
+        dark = cv2.bitwise_or(dark_otsu, dark_adapt)
+        dark = cv2.morphologyEx(dark, cv2.MORPH_OPEN, np.ones((2, 2), np.uint8))
+
+        contours, _ = cv2.findContours(dark, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+
+        border_x = int(w * 0.12)
+        border_y = int(h * 0.12)
+
+        pip_count = 0
+        for c in contours:
+            area = cv2.contourArea(c)
+            if area < 20 or area > 6000:
+                continue
+            perimeter = cv2.arcLength(c, True)
+            if perimeter == 0:
+                continue
+            if (4 * np.pi * area / (perimeter ** 2)) <= 0.55:
+                continue
+            M = cv2.moments(c)
+            if M['m00'] == 0:
+                continue
+            cx = int(M['m10'] / M['m00'])
+            cy = int(M['m01'] / M['m00'])
+            if cx < border_x or cx > w - border_x or cy < border_y or cy > h - border_y:
+                continue
+            pip_count += 1
+
+        return pip_count
+
+    # ------------------------------------------------------------------
+    # Service callback
+    # ------------------------------------------------------------------
+    def _capture_callback(self, _request, response):
+        self.get_logger().info('Capture request received.')
+        try:
+            frame = self._capture_image()
+            cv2.imwrite('dice_capture.jpg', frame)
+
+            bbox = self._find_die_bbox(frame)
+            if bbox is None:
+                self.get_logger().warn('No yellow die detected.')
+                response.success = False
+                response.pip_count = -1
+                response.message = 'No yellow die detected in image'
+                return response
+
+            count = self._count_pips(frame, bbox)
+            self.get_logger().info(f'Pip count: {count}')
+
+            response.success = True
+            response.pip_count = count
+            response.message = ''
+
+        except Exception as e:
+            self.get_logger().error(f'Camera error: {e}')
+            response.success = False
+            response.pip_count = -1
+            response.message = str(e)
+
+        return response
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = CameraServer()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/dice_game/dice_game/dj_control.py
+++ b/src/dice_game/dice_game/dj_control.py
@@ -1,0 +1,595 @@
+#!/usr/bin/env python3
+"""
+dj_control.py
+
+Master control node for DJ (Robot 1, LEFT, IP: 10.8.4.16).
+DJ is responsible for pips 1, 3, and 5.
+
+Conveyor assignment:
+  DJ controls the BACK (furthest) conveyor.
+  Odd pips  → back conveyor  (DJ runs it directly to send to BILL).
+  Even pips → front conveyor (BILL runs it — DJ just receives at its end).
+
+State machine:
+  FIND_START      → keep picking from table until pip == 1
+  SEND_TO_BILL    → request handoff, place on back conveyor, run until die clears
+  WAIT_FOR_RETURN → idle until BILL calls /DJ/request_handoff
+  RECEIVE         → wait for prox sensor, pick up from front conveyor
+  PRESENT_COUNT   → present to camera, loop until expected pip found
+  loop back to SEND_TO_BILL for pips 3 and 5
+  DONE            → game over (BILL places pip 6)
+"""
+
+import sys
+import time
+import threading
+
+import cv2
+import numpy as np
+
+import rclpy
+from rclpy.node import Node
+from rclpy.action import ActionClient
+from rclpy.callback_groups import ReentrantCallbackGroup, MutuallyExclusiveCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
+
+from fanuc_interfaces.action import JointPose, SchunkGripper, Conveyor
+from fanuc_interfaces.srv import RequestHandoff
+from fanuc_interfaces.msg import DiceState, ProxReadings
+
+sys.path.insert(0, 'src/dice_game/dice_game')
+import mvsdk
+
+# ============================================================
+# JOINT POSITIONS  — all values in degrees, [J1, J2, J3, J4, J5, J6]
+# ============================================================
+JOINTS = {
+    # ── General ──────────────────────────────────────────────────────────
+    'home':                       [0.0,    0.0,    0.0,    0.0,   -90.0,   30.0],
+    'initial_pickup':             [12.34,  24.21, -51.03, -0.01,  -38.97,  17.66],
+    'initial_pickup_up':          [12.34,  14.69, -33.40, -0.01,  -56.60,  17.66],
+
+    # ── Dice imaging — normal horizontal grip ────────────────────────────
+    'cam_pickup':                 [71.35,  42.61, -25.51, -0.91,  -66.07,  44.90],
+    'cam_pickup_up':              [71.35,  39.17, -15.94, -0.86,  -75.64,  44.75],
+
+    # ── Dice imaging — twist grip (vertical) ─────────────────────────────
+    'cam_pickup_twist':           [69.43,  40.24, -27.88, -1.85,  -61.39, -41.50],
+    'cam_pickup_twist_up':        [69.43,  36.39, -17.89, -1.71,  -71.37, -41.84],
+
+    # ── Camera presentation ───────────────────────────────────────────────
+    'cam_present':                [65.87,  20.85, -27.87, -135.54, -37.71, 168.74],
+
+    # ── Set die down on table ─────────────────────────────────────────────
+    'setdown':                    [34.03,  53.90, -75.45, -122.12, -83.09, 194.72],
+    'setdown_up':                 [34.30,  42.04, -65.02, -120.87, -77.55, 185.76],
+
+    # ── Waypoint between BILL conveyor receive and DJ's set-on-conveyor ──
+    'intermediate_dj_conveyor':   [88.60,  26.60,  -7.94,  -0.69,  -83.14,  30.37],
+
+    # ── DJ's back conveyor (send to BILL) ────────────────────────────────
+    'pre_set_on_conveyor':        [128.42, 36.69,  -0.81,  -1.22,  -89.58,  -9.54],
+    'set_on_conveyor':            [128.42, 38.38, -13.94,  -1.26,  -76.45,  -9.25],
+
+    # ── Receive from BILL's front conveyor ───────────────────────────────
+    'pick_bill_conveyor':     [119.02, 19.12, -26.84,  0.01,  -63.15,   -2.12],
+    'pre_pick_bill_conveyor':         [119.02, 14.84, -9.51,  0.01,  -80.49,   -2.12],
+}
+
+# Proximity sensors for DJ's back conveyor
+BACK_CONVEYOR_START_SENSOR  = 'left'    # near DJ's drop end
+BACK_CONVEYOR_STOP_SENSOR   = 'right'   # far end (BILL's side)
+
+# Sensor that trips when die arrives from BILL's front conveyor (DJ's receive end)
+FRONT_CONVEYOR_ARRIVE_SENSOR = 'left'   # TODO: confirm
+
+PROX_TIMEOUT          = 15.0
+MOTION_COMPLETE_TIMEOUT = 60.0
+
+DJ_IP   = '10.8.4.16'
+DJ_NAME = 'DJ'
+
+
+class DJControl(Node):
+    def __init__(self):
+        super().__init__('dj_control')
+
+        # Callback groups
+        self._action_cb = ReentrantCallbackGroup()
+        self._state_cb  = MutuallyExclusiveCallbackGroup()
+
+        # --- Action clients ---
+        self._joint_client  = ActionClient(self, JointPose,    'DJ/joint_pose',
+                                           callback_group=self._action_cb)
+        self._schunk_client = ActionClient(self, SchunkGripper, 'DJ/schunk_gripper',
+                                           callback_group=self._action_cb)
+        self._convey_client = ActionClient(self, Conveyor,      'DJ/conveyor',
+                                           callback_group=self._action_cb)
+
+        # --- Service clients ---
+        self._bill_handoff_cli = self.create_client(RequestHandoff, '/BILL/request_handoff',
+                                                     callback_group=self._action_cb)
+
+        # --- Handoff service server (BILL calls this to send dice back to DJ) ---
+        self._handoff_server = self.create_service(
+            RequestHandoff, '/DJ/request_handoff',
+            self._handle_handoff,
+            callback_group=self._action_cb,
+        )
+
+        # --- State publisher ---
+        self._state_pub = self.create_publisher(DiceState, '/dice_state', 10)
+
+        # --- Internal state ---
+        self._dj_retries   = 0
+        self._bill_retries = 0
+        self._expected_pip = 1
+        self._last_prox    = {'right': 0, 'left': 0}
+        self._handoff_received = threading.Event()
+        self._annotated    = None
+
+        # Subscribe to BILL's retry updates
+        self.create_subscription(DiceState, '/dice_state', self._state_cb_fn, 10)
+
+        self.get_logger().info('DJ control node ready.')
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+    def _wait(self, future, timeout: float = 30.0):
+        deadline = time.time() + timeout
+        while not future.done():
+            if time.time() > deadline:
+                raise TimeoutError(f'Future timed out after {timeout}s')
+            time.sleep(0.02)
+        return future.result()
+
+    # ------------------------------------------------------------------
+    # Robot primitives
+    # ------------------------------------------------------------------
+    def _move(self, joints: list, speed: int = 0):
+        self.get_logger().info(f'Move → {joints}' + (f' @ {speed}mm/s' if speed else ''))
+        goal = JointPose.Goal()
+        goal.joint1, goal.joint2, goal.joint3 = joints[0], joints[1], joints[2]
+        goal.joint4, goal.joint5, goal.joint6 = joints[3], joints[4], joints[5]
+        goal.speed = speed
+        self._joint_client.wait_for_server()
+        gh = self._wait(self._joint_client.send_goal_async(goal))
+        if not gh.accepted:
+            raise RuntimeError('Joint move goal rejected')
+        self._wait(gh.get_result_async(), timeout=MOTION_COMPLETE_TIMEOUT)
+
+    def _gripper(self, command: str):
+        """'open' or 'close' the Schunk gripper."""
+        goal = SchunkGripper.Goal()
+        goal.command = command
+        self._schunk_client.wait_for_server()
+        gh = self._wait(self._schunk_client.send_goal_async(goal))
+        if not gh.accepted:
+            raise RuntimeError(f'Gripper goal rejected: {command}')
+        self._wait(gh.get_result_async())
+        self.get_logger().info(f'Gripper {command.upper()}')
+        time.sleep(2.0)
+
+    def _conveyor(self, command: str):
+        goal = Conveyor.Goal()
+        goal.command = command
+        self._convey_client.wait_for_server()
+        gh = self._wait(self._convey_client.send_goal_async(goal))
+        if not gh.accepted:
+            raise RuntimeError(f'Conveyor goal rejected: {command}')
+        self._wait(gh.get_result_async())
+
+    def _wait_for_prox_trip(self, side: str, timeout: float = PROX_TIMEOUT):
+        deadline = time.time() + timeout
+        self.get_logger().info(f'  Waiting for {side} sensor to trip...')
+        while self._last_prox.get(side, 0) == 0:
+            if time.time() > deadline:
+                raise TimeoutError(f'{side} sensor never tripped (timeout {timeout}s)')
+            time.sleep(0.05)
+        self.get_logger().info(f'  {side} sensor tripped.')
+
+    def _run_conveyor_sensors(self, start_sensor: str, stop_sensor: str):
+        self.get_logger().info('Waiting for die to load (start sensor)...')
+        self._wait_for_prox_trip(start_sensor, timeout=20.0)
+        self._conveyor('forward')
+        self.get_logger().info('Conveyor running — waiting for die to arrive (stop sensor)...')
+        try:
+            self._wait_for_prox_trip(stop_sensor, timeout=20.0)
+            self.get_logger().info('Stop sensor tripped — running 2 more seconds...')
+            time.sleep(2.0)
+        finally:
+            self._conveyor('stop')
+        self.get_logger().info('Conveyor stopped — die delivered.')
+
+    # ------------------------------------------------------------------
+    # Camera
+    # ------------------------------------------------------------------
+    def _capture_image(self) -> np.ndarray:
+        devs = mvsdk.CameraEnumerateDevice()
+        if len(devs) < 1:
+            raise RuntimeError('No MindVision camera found. Check ethernet cable.')
+
+        hCamera = None
+        for attempt in range(5):
+            try:
+                hCamera = mvsdk.CameraInit(devs[0], -1, -1)
+                break
+            except Exception as e:
+                self.get_logger().warn(f'CameraInit attempt {attempt+1} failed: {e}')
+                time.sleep(2.0)
+        if hCamera is None:
+            raise RuntimeError('CameraInit failed after 5 attempts')
+
+        cap = mvsdk.CameraGetCapability(hCamera)
+        mono = (cap.sIspCapacity.bMonoSensor != 0)
+        fmt = mvsdk.CAMERA_MEDIA_TYPE_MONO8 if mono else mvsdk.CAMERA_MEDIA_TYPE_BGR8
+        mvsdk.CameraSetIspOutFormat(hCamera, fmt)
+        mvsdk.CameraSetTriggerMode(hCamera, 0)
+        mvsdk.CameraSetAeState(hCamera, 0)
+        mvsdk.CameraSetExposureTime(hCamera, 30 * 1000)
+        mvsdk.CameraPlay(hCamera)
+
+        channels = 1 if mono else 3
+        buf_size = cap.sResolutionRange.iWidthMax * cap.sResolutionRange.iHeightMax * channels
+        pFrameBuffer = mvsdk.CameraAlignMalloc(buf_size, 16)
+        try:
+            pRawData, FrameHead = mvsdk.CameraGetImageBuffer(hCamera, 2000)
+            mvsdk.CameraImageProcess(hCamera, pRawData, pFrameBuffer, FrameHead)
+            mvsdk.CameraReleaseImageBuffer(hCamera, pRawData)
+            frame_data = (mvsdk.c_ubyte * FrameHead.uBytes).from_address(pFrameBuffer)
+            frame = np.frombuffer(frame_data, dtype=np.uint8).reshape(
+                (FrameHead.iHeight, FrameHead.iWidth, channels))
+            return frame.copy()
+        finally:
+            mvsdk.CameraUnInit(hCamera)
+            mvsdk.CameraAlignFree(pFrameBuffer)
+
+    def _count_pips(self, image: np.ndarray) -> int:
+        hsv = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
+        mask = cv2.inRange(hsv, np.array([15, 60, 40]), np.array([45, 255, 255]))
+        kernel = np.ones((5, 5), np.uint8)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel, iterations=2)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN,  kernel, iterations=1)
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        if not contours:
+            self.get_logger().warn('No yellow die detected in image')
+            self._annotated = image.copy()
+            return -1
+
+        x, y, w, h = cv2.boundingRect(max(contours, key=cv2.contourArea))
+        margin = 8
+        x = max(0, x - margin);  y = max(0, y - margin)
+        w = min(image.shape[1] - x, w + 2 * margin)
+        h = min(image.shape[0] - y, h + 2 * margin)
+
+        roi = image[y:y+h, x:x+w].copy()
+        roi_bright = cv2.convertScaleAbs(roi, alpha=3.5, beta=50)
+        gray = cv2.cvtColor(roi_bright, cv2.COLOR_BGR2GRAY)
+        blur = cv2.GaussianBlur(gray, (3, 3), 0)
+
+        _, dark_otsu = cv2.threshold(blur, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+        dark_adapt = cv2.adaptiveThreshold(
+            blur, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, cv2.THRESH_BINARY_INV, 21, 8)
+        dark = cv2.bitwise_or(dark_otsu, dark_adapt)
+        dark = cv2.morphologyEx(dark, cv2.MORPH_OPEN, np.ones((2, 2), np.uint8))
+
+        pip_contours, _ = cv2.findContours(dark, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        border_x = int(w * 0.12);  border_y = int(h * 0.12)
+        pip_count = 0
+        annotated = image.copy()
+        cv2.rectangle(annotated, (x, y), (x+w, y+h), (255, 0, 0), 2)
+
+        for c in pip_contours:
+            area = cv2.contourArea(c)
+            if area < 20 or area > 6000:
+                continue
+            perimeter = cv2.arcLength(c, True)
+            if perimeter == 0 or (4 * np.pi * area / (perimeter ** 2)) <= 0.55:
+                continue
+            M = cv2.moments(c)
+            if M['m00'] == 0:
+                continue
+            cx = int(M['m10'] / M['m00']) + x
+            cy = int(M['m01'] / M['m00']) + y
+            if (cx - x) < border_x or (cx - x) > w - border_x:
+                continue
+            if (cy - y) < border_y or (cy - y) > h - border_y:
+                continue
+            pip_count += 1
+            cv2.drawContours(annotated, [c + np.array([[[x, y]]])], -1, (0, 255, 0), 2)
+            cv2.circle(annotated, (cx, cy), 4, (0, 0, 255), -1)
+
+        cv2.putText(annotated, f'pips: {pip_count}', (10, 40),
+                    cv2.FONT_HERSHEY_SIMPLEX, 1.2, (0, 255, 0), 2)
+        self._annotated = annotated
+        return pip_count
+
+    def _capture_and_show(self, label: str, target: int = 0) -> int:
+        self.get_logger().info(f'Capturing ({label})...')
+        frame = self._capture_image()
+        count = self._count_pips(frame)
+        self.get_logger().info(f'Pip count: {count}')
+        cv2.imwrite('dice_capture.jpg', frame)
+        cv2.imwrite('dice_annotated.jpg', self._annotated)
+        return count
+
+    # ------------------------------------------------------------------
+    # Movement sub-routines (proven in dj_cam_test.py)
+    # ------------------------------------------------------------------
+    def _normal_pickup_present(self, label: str, target: int) -> int:
+        """Pick up from table (horizontal), present to camera. Still holding die."""
+        self._move(JOINTS['cam_pickup_up'], speed=300)
+        self._move(JOINTS['cam_pickup'])
+        self._gripper('close')
+        self._move(JOINTS['cam_pickup_up'])
+        self._move(JOINTS['cam_present'], speed=50)
+        return self._capture_and_show(label, target)
+
+    def _twist_pickup_present(self, label: str, target: int) -> int:
+        """Pick up from table (twist/vertical), present to camera. Still holding die."""
+        self._move(JOINTS['cam_pickup_twist_up'], speed=300)
+        self._move(JOINTS['cam_pickup_twist'])
+        self._gripper('close')
+        self._move(JOINTS['cam_pickup_twist_up'])
+        self._move(JOINTS['cam_pickup_up'])
+        self._move(JOINTS['cam_present'], speed=50)
+        return self._capture_and_show(label, target)
+
+    def _set_down(self):
+        """Set die back down on table from cam_present position."""
+        self._move(JOINTS['setdown_up'])
+        self._move(JOINTS['setdown'])
+        self._gripper('open')
+        self._move(JOINTS['setdown_up'])
+        self._dj_retries += 1
+
+    def _place_on_back_conveyor(self):
+        """Set die down normally, re-pick with twist, place on DJ's back conveyor."""
+        self._set_down()
+        self._move(JOINTS['cam_pickup_up'], speed=300)
+        self._move(JOINTS['cam_pickup'])
+        self._gripper('close')
+        self._move(JOINTS['cam_pickup_up'])
+        self._move(JOINTS['intermediate_dj_conveyor'])
+        self._move(JOINTS['pre_set_on_conveyor'])
+        self._move(JOINTS['set_on_conveyor'])
+        self._gripper('open')
+        self._move(JOINTS['pre_set_on_conveyor'])
+
+    # ------------------------------------------------------------------
+    # State
+    # ------------------------------------------------------------------
+    def _publish_state(self, robot_holding: str):
+        msg = DiceState()
+        msg.expected_pip  = self._expected_pip
+        msg.dj_retries    = self._dj_retries
+        msg.bill_retries  = self._bill_retries
+        msg.robot_holding = robot_holding
+        self._state_pub.publish(msg)
+
+    def _state_cb_fn(self, msg: DiceState):
+        self._bill_retries = msg.bill_retries
+
+    # ------------------------------------------------------------------
+    # Handoff service server (BILL calls this when sending dice back to DJ)
+    # ------------------------------------------------------------------
+    def _handle_handoff(self, request: RequestHandoff.Request,
+                        response: RequestHandoff.Response):
+        self.get_logger().info('Handoff request from BILL — moving to pre-pick position.')
+        self._move(JOINTS['home'])
+        self._gripper('open')
+        self._move(JOINTS['pre_pick_bill_conveyor'])
+        response.accepted = True
+        self._handoff_received.set()
+        return response
+
+    # ------------------------------------------------------------------
+    # State machine sub-steps
+    # ------------------------------------------------------------------
+    def _find_pip(self, target: int):
+        """
+        Initial search — die starts at initial_pickup position.
+        First pick uses initial_pickup, then loops using cam_pickup.
+        """
+        self.get_logger().info(f'=== DJ searching for pip {target} (initial pickup) ===')
+        self._gripper('open')
+        attempt = 0
+        twist_done = False
+        capture_num = 0
+
+        # First pick from initial position
+        capture_num += 1
+        self.get_logger().info(f'Move → {JOINTS["initial_pickup_up"]} @ 300mm/s')
+        self._move(JOINTS['initial_pickup_up'], speed=300)
+        self._move(JOINTS['initial_pickup'])
+        self._gripper('close')
+        self._move(JOINTS['initial_pickup_up'])
+        self._move(JOINTS['cam_present'], speed=50)
+        count = self._capture_and_show(f'initial_{capture_num}', target)
+        self.get_logger().info(f'  Pip count: {count}  (need {target})')
+        self._publish_state('DJ')
+        if count == target:
+            self.get_logger().info(f'  Found pip {target} on first pick!')
+            return
+        self._set_down()
+        attempt += 1
+
+        while True:
+            if attempt == 3 and not twist_done:
+                self.get_logger().info('3 attempts failed — trying twist grip')
+                capture_num += 1
+                count = self._twist_pickup_present(f'twist_{capture_num}', target)
+                self.get_logger().info(f'  Pip count: {count}  (need {target})')
+                self._publish_state('DJ')
+                if count == target:
+                    self.get_logger().info(f'  Found pip {target} on twist!')
+                    return
+                self._set_down()
+                twist_done = True
+
+            capture_num += 1
+            count = self._normal_pickup_present(f'normal_{capture_num}', target)
+            self.get_logger().info(f'  Pip count: {count}  (need {target})')
+            self._publish_state('DJ')
+            if count == target:
+                self.get_logger().info(f'  Found pip {target}!')
+                return
+            self._set_down()
+            attempt += 1
+
+    def _present_and_count(self, target: int):
+        """
+        Already holding die (just picked from BILL's conveyor, at pre_pick_bill_conveyor).
+        Route to cam_present, loop until target pip found. Returns holding die.
+        """
+        self.get_logger().info(f'=== DJ searching for pip {target} ===')
+        attempt = 0
+        twist_done = False
+        capture_num = 0
+
+        # First present: route through intermediate waypoint from BILL's conveyor
+        capture_num += 1
+        self._move(JOINTS['intermediate_dj_conveyor'])
+        self._move(JOINTS['cam_present'], speed=50)
+        count = self._capture_and_show(f'bill_conveyor_{capture_num}', target)
+        self.get_logger().info(f'  Pip count: {count}  (need {target})')
+        self._publish_state('DJ')
+        if count == target:
+            self.get_logger().info(f'  Found pip {target} on first present!')
+            return
+        self._set_down()
+        attempt += 1
+
+        while True:
+            if attempt == 4 and not twist_done:
+                self.get_logger().info('3 normal attempts failed — trying twist grip')
+                capture_num += 1
+                count = self._twist_pickup_present(f'twist_{capture_num}', target)
+                self.get_logger().info(f'  Pip count: {count}  (need {target})')
+                self._publish_state('DJ')
+                if count == target:
+                    self.get_logger().info(f'  Found pip {target} on twist!')
+                    return
+                self._set_down()
+                twist_done = True
+
+            capture_num += 1
+            count = self._normal_pickup_present(f'normal_{capture_num}', target)
+            self.get_logger().info(f'  Pip count: {count}  (need {target})')
+            self._publish_state('DJ')
+            if count == target:
+                self.get_logger().info(f'  Found pip {target}!')
+                return
+            self._set_down()
+            attempt += 1
+
+    def _send_to_bill(self):
+        """
+        Already holding die at cam_present. Place on back conveyor, run belt until
+        delivered, then signal BILL to come pick up.
+        """
+        self.get_logger().info('Placing die on back conveyor...')
+        self._place_on_back_conveyor()
+        self._move(JOINTS['home'])
+
+        self._publish_state('IN_TRANSIT')
+        self._run_conveyor_sensors(BACK_CONVEYOR_START_SENSOR, BACK_CONVEYOR_STOP_SENSOR)
+
+        # Die is now at BILL's end — signal BILL to pick up
+        self.get_logger().info('Die delivered — signaling BILL to pick up...')
+        req = RequestHandoff.Request()
+        req.conveyor = 'back'
+        self._bill_handoff_cli.wait_for_service()
+        future = self._bill_handoff_cli.call_async(req)
+        resp = self._wait(future, timeout=30.0)
+        if not resp.accepted:
+            raise RuntimeError('BILL rejected handoff request')
+
+    def _wait_for_return(self):
+        """
+        Wait for BILL to signal die has been delivered, then pick up from BILL's conveyor.
+        (_handle_handoff moves DJ to pre_pick_bill_conveyor — die is already there.)
+        """
+        self.get_logger().info('Waiting for BILL to send die back...')
+        self._handoff_received.clear()
+        self._handoff_received.wait()
+        # Die is already at DJ's pick position (BILL ran conveyor before calling handoff)
+        # _handle_handoff already moved DJ to pre_pick_bill_conveyor
+
+        # Pick up die
+        self._move(JOINTS['pick_bill_conveyor'])
+        self._gripper('close')
+        self._move(JOINTS['pre_pick_bill_conveyor'])
+        self.get_logger().info('Die received from BILL.')
+
+    # ------------------------------------------------------------------
+    # Main state machine
+    # ------------------------------------------------------------------
+    def run(self):
+        self.get_logger().info('=== DJ state machine starting ===')
+
+        # Subscribe to prox readings
+        self.create_subscription(
+            ProxReadings, 'DJ/prox_readings',
+            lambda msg: self._last_prox.update({'right': msg.right, 'left': msg.left}),
+            10,
+        )
+
+        # ---- Phase 1: Find pip = 1 from table ----------------------------
+        self._expected_pip = 1
+        self.get_logger().info('--- Phase 1: Finding pip = 1 from table ---')
+        self._find_pip(target=1)
+
+        # ---- DJ handles 1 → send to BILL, receive back for 3 → send, etc.
+        for expected_dj in [1, 3, 5]:
+            self._expected_pip = expected_dj
+            self.get_logger().info(f'--- DJ sending pip {expected_dj} to BILL ---')
+            self._send_to_bill()
+
+            next_dj_pip = expected_dj + 2   # 3, 5, or 7 (7 = pip 6 return)
+            self.get_logger().info(f'--- DJ waiting to receive die back ---')
+            self._wait_for_return()
+
+            if expected_dj == 5:
+                # BILL found pip 6 and sent it back — set it down at the start position
+                self.get_logger().info('--- Pip 6 received — setting die down at start position ---')
+                self._move(JOINTS['intermediate_dj_conveyor'])
+                self._move(JOINTS['initial_pickup_up'])
+                self._move(JOINTS['initial_pickup'])
+                self._gripper('open')
+                self._move(JOINTS['initial_pickup_up'])
+                self._move(JOINTS['home'])
+                self.get_logger().info('=== Game complete! ===')
+                self._publish_state('DONE')
+                return
+
+            self._expected_pip = next_dj_pip
+            self._present_and_count(target=next_dj_pip)
+
+        self.get_logger().info('=== DJ done. ===')
+        self._publish_state('DONE')
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = DJControl()
+
+    executor = MultiThreadedExecutor(num_threads=4)
+    executor.add_node(node)
+
+    spin_thread = threading.Thread(target=executor.spin, daemon=True)
+    spin_thread.start()
+
+    try:
+        node.run()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        executor.shutdown()
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/dice_game/dice_game/mvsdk.py
+++ b/src/dice_game/dice_game/mvsdk.py
@@ -1,0 +1,2394 @@
+#coding=utf-8
+import platform
+from ctypes import *
+from threading import local
+
+# 回调函数类型
+CALLBACK_FUNC_TYPE = None
+
+# SDK动态库
+_sdk = None
+
+def _Init():
+	global _sdk
+	global CALLBACK_FUNC_TYPE
+
+	is_win = (platform.system() == "Windows")
+	is_x86 = (platform.architecture()[0] == '32bit')
+
+	if is_win:
+		_sdk = windll.MVCAMSDK if is_x86 else windll.MVCAMSDK_X64
+		CALLBACK_FUNC_TYPE = WINFUNCTYPE
+	else:
+		_sdk = cdll.LoadLibrary("libMVSDK.so")
+		CALLBACK_FUNC_TYPE = CFUNCTYPE
+
+_Init()
+
+#-------------------------------------------类型定义--------------------------------------------------
+
+# 状态码定义
+CAMERA_STATUS_SUCCESS = 0   # 操作成功
+CAMERA_STATUS_FAILED = -1   # 操作失败
+CAMERA_STATUS_INTERNAL_ERROR = -2   # 内部错误
+CAMERA_STATUS_UNKNOW = -3   # 未知错误
+CAMERA_STATUS_NOT_SUPPORTED = -4   # 不支持该功能
+CAMERA_STATUS_NOT_INITIALIZED = -5   # 初始化未完成
+CAMERA_STATUS_PARAMETER_INVALID = -6   # 参数无效
+CAMERA_STATUS_PARAMETER_OUT_OF_BOUND = -7   # 参数越界
+CAMERA_STATUS_UNENABLED = -8   # 未使能
+CAMERA_STATUS_USER_CANCEL = -9   # 用户手动取消了，比如roi面板点击取消，返回
+CAMERA_STATUS_PATH_NOT_FOUND = -10  # 注册表中没有找到对应的路径
+CAMERA_STATUS_SIZE_DISMATCH = -11  # 获得图像数据长度和定义的尺寸不匹配
+CAMERA_STATUS_TIME_OUT = -12  # 超时错误
+CAMERA_STATUS_IO_ERROR = -13  # 硬件IO错误
+CAMERA_STATUS_COMM_ERROR = -14  # 通讯错误
+CAMERA_STATUS_BUS_ERROR = -15  # 总线错误
+CAMERA_STATUS_NO_DEVICE_FOUND = -16  # 没有发现设备
+CAMERA_STATUS_NO_LOGIC_DEVICE_FOUND = -17  # 未找到逻辑设备
+CAMERA_STATUS_DEVICE_IS_OPENED = -18  # 设备已经打开
+CAMERA_STATUS_DEVICE_IS_CLOSED = -19  # 设备已经关闭
+CAMERA_STATUS_DEVICE_VEDIO_CLOSED = -20  # 没有打开设备视频，调用录像相关的函数时，如果相机视频没有打开，则回返回该错误。
+CAMERA_STATUS_NO_MEMORY = -21  # 没有足够系统内存
+CAMERA_STATUS_FILE_CREATE_FAILED = -22  # 创建文件失败
+CAMERA_STATUS_FILE_INVALID = -23  # 文件格式无效
+CAMERA_STATUS_WRITE_PROTECTED = -24  # 写保护，不可写
+CAMERA_STATUS_GRAB_FAILED = -25  # 数据采集失败
+CAMERA_STATUS_LOST_DATA = -26  # 数据丢失，不完整
+CAMERA_STATUS_EOF_ERROR = -27  # 未接收到帧结束符
+CAMERA_STATUS_BUSY = -28  # 正忙(上一次操作还在进行中)，此次操作不能进行
+CAMERA_STATUS_WAIT = -29  # 需要等待(进行操作的条件不成立)，可以再次尝试
+CAMERA_STATUS_IN_PROCESS = -30  # 正在进行，已经被操作过
+CAMERA_STATUS_IIC_ERROR = -31  # IIC传输错误
+CAMERA_STATUS_SPI_ERROR = -32  # SPI传输错误
+CAMERA_STATUS_USB_CONTROL_ERROR = -33  # USB控制传输错误
+CAMERA_STATUS_USB_BULK_ERROR = -34  # USB BULK传输错误
+CAMERA_STATUS_SOCKET_INIT_ERROR = -35  # 网络传输套件初始化失败
+CAMERA_STATUS_GIGE_FILTER_INIT_ERROR = -36  # 网络相机内核过滤驱动初始化失败，请检查是否正确安装了驱动，或者重新安装。
+CAMERA_STATUS_NET_SEND_ERROR = -37  # 网络数据发送错误
+CAMERA_STATUS_DEVICE_LOST = -38  # 与网络相机失去连接，心跳检测超时
+CAMERA_STATUS_DATA_RECV_LESS = -39  # 接收到的字节数比请求的少 
+CAMERA_STATUS_FUNCTION_LOAD_FAILED = -40  # 从文件中加载程序失败
+CAMERA_STATUS_CRITICAL_FILE_LOST = -41  # 程序运行所必须的文件丢失。
+CAMERA_STATUS_SENSOR_ID_DISMATCH = -42  # 固件和程序不匹配，原因是下载了错误的固件。
+CAMERA_STATUS_OUT_OF_RANGE = -43  # 参数超出有效范围。   
+CAMERA_STATUS_REGISTRY_ERROR = -44  # 安装程序注册错误。请重新安装程序，或者运行安装目录Setup/Installer.exe
+CAMERA_STATUS_ACCESS_DENY = -45  # 禁止访问。指定相机已经被其他程序占用时，再申请访问该相机，会返回该状态。(一个相机不能被多个程序同时访问) 
+#AIA的标准兼容的错误码
+CAMERA_AIA_PACKET_RESEND = 0x0100 #该帧需要重传
+CAMERA_AIA_NOT_IMPLEMENTED = 0x8001 #设备不支持的命令
+CAMERA_AIA_INVALID_PARAMETER = 0x8002 #命令参数非法
+CAMERA_AIA_INVALID_ADDRESS = 0x8003 #不可访问的地址
+CAMERA_AIA_WRITE_PROTECT = 0x8004 #访问的对象不可写
+CAMERA_AIA_BAD_ALIGNMENT = 0x8005 #访问的地址没有按照要求对齐
+CAMERA_AIA_ACCESS_DENIED = 0x8006 #没有访问权限
+CAMERA_AIA_BUSY = 0x8007 #命令正在处理中
+CAMERA_AIA_DEPRECATED = 0x8008 #0x8008-0x0800B  0x800F  该指令已经废弃
+CAMERA_AIA_PACKET_UNAVAILABLE = 0x800C #包无效
+CAMERA_AIA_DATA_OVERRUN = 0x800D #数据溢出，通常是收到的数据比需要的多
+CAMERA_AIA_INVALID_HEADER = 0x800E #数据包头部中某些区域与协议不匹配
+CAMERA_AIA_PACKET_NOT_YET_AVAILABLE = 0x8010 #图像分包数据还未准备好，多用于触发模式，应用程序访问超时
+CAMERA_AIA_PACKET_AND_PREV_REMOVED_FROM_MEMORY = 0x8011 #需要访问的分包已经不存在。多用于重传时数据已经不在缓冲区中
+CAMERA_AIA_PACKET_REMOVED_FROM_MEMORY = 0x8012 #CAMERA_AIA_PACKET_AND_PREV_REMOVED_FROM_MEMORY
+CAMERA_AIA_NO_REF_TIME = 0x0813 #没有参考时钟源。多用于时间同步的命令执行时
+CAMERA_AIA_PACKET_TEMPORARILY_UNAVAILABLE = 0x0814 #由于信道带宽问题，当前分包暂时不可用，需稍后进行访问
+CAMERA_AIA_OVERFLOW = 0x0815 #设备端数据溢出，通常是队列已满
+CAMERA_AIA_ACTION_LATE = 0x0816 #命令执行已经超过有效的指定时间
+CAMERA_AIA_ERROR = 0x8FFF   #错误
+
+# 图像格式定义
+CAMERA_MEDIA_TYPE_MONO = 0x01000000
+CAMERA_MEDIA_TYPE_RGB = 0x02000000
+CAMERA_MEDIA_TYPE_COLOR = 0x02000000
+CAMERA_MEDIA_TYPE_OCCUPY1BIT = 0x00010000
+CAMERA_MEDIA_TYPE_OCCUPY2BIT = 0x00020000
+CAMERA_MEDIA_TYPE_OCCUPY4BIT = 0x00040000
+CAMERA_MEDIA_TYPE_OCCUPY8BIT = 0x00080000
+CAMERA_MEDIA_TYPE_OCCUPY10BIT = 0x000A0000
+CAMERA_MEDIA_TYPE_OCCUPY12BIT = 0x000C0000
+CAMERA_MEDIA_TYPE_OCCUPY16BIT = 0x00100000
+CAMERA_MEDIA_TYPE_OCCUPY24BIT = 0x00180000
+CAMERA_MEDIA_TYPE_OCCUPY32BIT = 0x00200000
+CAMERA_MEDIA_TYPE_OCCUPY36BIT = 0x00240000
+CAMERA_MEDIA_TYPE_OCCUPY48BIT = 0x00300000
+CAMERA_MEDIA_TYPE_EFFECTIVE_PIXEL_SIZE_MASK = 0x00FF0000
+CAMERA_MEDIA_TYPE_EFFECTIVE_PIXEL_SIZE_SHIFT = 16
+CAMERA_MEDIA_TYPE_ID_MASK = 0x0000FFFF
+CAMERA_MEDIA_TYPE_COUNT = 0x46
+
+#mono
+CAMERA_MEDIA_TYPE_MONO1P = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY1BIT | 0x0037)
+CAMERA_MEDIA_TYPE_MONO2P = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY2BIT | 0x0038)
+CAMERA_MEDIA_TYPE_MONO4P = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY4BIT | 0x0039)
+CAMERA_MEDIA_TYPE_MONO8 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY8BIT | 0x0001)
+CAMERA_MEDIA_TYPE_MONO8S = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY8BIT | 0x0002)
+CAMERA_MEDIA_TYPE_MONO10 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0003)
+CAMERA_MEDIA_TYPE_MONO10_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x0004)
+CAMERA_MEDIA_TYPE_MONO12 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0005)
+CAMERA_MEDIA_TYPE_MONO12_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x0006)
+CAMERA_MEDIA_TYPE_MONO14 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0025)
+CAMERA_MEDIA_TYPE_MONO16 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0007)
+
+# Bayer
+CAMERA_MEDIA_TYPE_BAYGR8 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY8BIT | 0x0008)
+CAMERA_MEDIA_TYPE_BAYRG8 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY8BIT | 0x0009)
+CAMERA_MEDIA_TYPE_BAYGB8 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY8BIT | 0x000A)
+CAMERA_MEDIA_TYPE_BAYBG8 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY8BIT | 0x000B)
+
+CAMERA_MEDIA_TYPE_BAYGR10_MIPI = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY10BIT | 0x0026)
+CAMERA_MEDIA_TYPE_BAYRG10_MIPI = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY10BIT | 0x0027)
+CAMERA_MEDIA_TYPE_BAYGB10_MIPI = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY10BIT | 0x0028)
+CAMERA_MEDIA_TYPE_BAYBG10_MIPI = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY10BIT | 0x0029)
+
+CAMERA_MEDIA_TYPE_BAYGR10 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x000C)
+CAMERA_MEDIA_TYPE_BAYRG10 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x000D)
+CAMERA_MEDIA_TYPE_BAYGB10 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x000E)
+CAMERA_MEDIA_TYPE_BAYBG10 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x000F)
+
+CAMERA_MEDIA_TYPE_BAYGR12 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0010)
+CAMERA_MEDIA_TYPE_BAYRG12 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0011)
+CAMERA_MEDIA_TYPE_BAYGB12 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0012)
+CAMERA_MEDIA_TYPE_BAYBG12 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0013)
+
+CAMERA_MEDIA_TYPE_BAYGR10_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x0026)
+CAMERA_MEDIA_TYPE_BAYRG10_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x0027)
+CAMERA_MEDIA_TYPE_BAYGB10_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x0028)
+CAMERA_MEDIA_TYPE_BAYBG10_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x0029)
+
+CAMERA_MEDIA_TYPE_BAYGR12_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x002A)
+CAMERA_MEDIA_TYPE_BAYRG12_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x002B)
+CAMERA_MEDIA_TYPE_BAYGB12_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x002C)
+CAMERA_MEDIA_TYPE_BAYBG12_PACKED = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x002D)
+
+CAMERA_MEDIA_TYPE_BAYGR16 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x002E)
+CAMERA_MEDIA_TYPE_BAYRG16 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x002F)
+CAMERA_MEDIA_TYPE_BAYGB16 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0030)
+CAMERA_MEDIA_TYPE_BAYBG16 = (CAMERA_MEDIA_TYPE_MONO | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0031)
+
+# RGB
+CAMERA_MEDIA_TYPE_RGB8 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY24BIT | 0x0014)
+CAMERA_MEDIA_TYPE_BGR8 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY24BIT | 0x0015)
+CAMERA_MEDIA_TYPE_RGBA8 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY32BIT | 0x0016)
+CAMERA_MEDIA_TYPE_BGRA8 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY32BIT | 0x0017)
+CAMERA_MEDIA_TYPE_RGB10 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY48BIT | 0x0018)
+CAMERA_MEDIA_TYPE_BGR10 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY48BIT | 0x0019)
+CAMERA_MEDIA_TYPE_RGB12 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY48BIT | 0x001A)
+CAMERA_MEDIA_TYPE_BGR12 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY48BIT | 0x001B)
+CAMERA_MEDIA_TYPE_RGB16 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY48BIT | 0x0033)
+CAMERA_MEDIA_TYPE_RGB10V1_PACKED = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY32BIT | 0x001C)
+CAMERA_MEDIA_TYPE_RGB10P32 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY32BIT | 0x001D)
+CAMERA_MEDIA_TYPE_RGB12V1_PACKED = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY36BIT | 0X0034)
+CAMERA_MEDIA_TYPE_RGB565P = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0035)
+CAMERA_MEDIA_TYPE_BGR565P = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0X0036)
+
+# YUV and YCbCr
+CAMERA_MEDIA_TYPE_YUV411_8_UYYVYY = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x001E)
+CAMERA_MEDIA_TYPE_YUV422_8_UYVY = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x001F)
+CAMERA_MEDIA_TYPE_YUV422_8 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0032)
+CAMERA_MEDIA_TYPE_YUV8_UYV = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY24BIT | 0x0020)
+CAMERA_MEDIA_TYPE_YCBCR8_CBYCR = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY24BIT | 0x003A)
+#CAMERA_MEDIA_TYPE_YCBCR422_8 : YYYYCbCrCbCr
+CAMERA_MEDIA_TYPE_YCBCR422_8 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x003B)
+CAMERA_MEDIA_TYPE_YCBCR422_8_CBYCRY = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0043)
+CAMERA_MEDIA_TYPE_YCBCR411_8_CBYYCRYY = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x003C)
+CAMERA_MEDIA_TYPE_YCBCR601_8_CBYCR = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY24BIT | 0x003D)
+CAMERA_MEDIA_TYPE_YCBCR601_422_8 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x003E)
+CAMERA_MEDIA_TYPE_YCBCR601_422_8_CBYCRY = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0044)
+CAMERA_MEDIA_TYPE_YCBCR601_411_8_CBYYCRYY = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x003F)
+CAMERA_MEDIA_TYPE_YCBCR709_8_CBYCR = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY24BIT | 0x0040)
+CAMERA_MEDIA_TYPE_YCBCR709_422_8 = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0041)
+CAMERA_MEDIA_TYPE_YCBCR709_422_8_CBYCRY = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY16BIT | 0x0045)
+CAMERA_MEDIA_TYPE_YCBCR709_411_8_CBYYCRYY = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY12BIT | 0x0042)
+
+# RGB Planar
+CAMERA_MEDIA_TYPE_RGB8_PLANAR = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY24BIT | 0x0021)
+CAMERA_MEDIA_TYPE_RGB10_PLANAR = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY48BIT | 0x0022)
+CAMERA_MEDIA_TYPE_RGB12_PLANAR = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY48BIT | 0x0023)
+CAMERA_MEDIA_TYPE_RGB16_PLANAR = (CAMERA_MEDIA_TYPE_COLOR | CAMERA_MEDIA_TYPE_OCCUPY48BIT | 0x0024)
+
+# 保存格式
+FILE_JPG = 1
+FILE_BMP = 2
+FILE_RAW = 4
+FILE_PNG = 8 
+FILE_BMP_8BIT = 16
+FILE_PNG_8BIT = 32
+FILE_RAW_16BIT = 64
+
+# 触发信号
+EXT_TRIG_LEADING_EDGE = 0
+EXT_TRIG_TRAILING_EDGE = 1
+EXT_TRIG_HIGH_LEVEL = 2
+EXT_TRIG_LOW_LEVEL = 3
+EXT_TRIG_DOUBLE_EDGE = 4
+
+# IO模式
+IOMODE_TRIG_INPUT = 0
+IOMODE_STROBE_OUTPUT = 1
+IOMODE_GP_INPUT = 2
+IOMODE_GP_OUTPUT = 3
+IOMODE_PWM_OUTPUT = 4
+
+
+# 相机操作异常信息
+class CameraException(Exception):
+	"""docstring for CameraException"""
+	def __init__(self, error_code):
+		super(CameraException, self).__init__()
+		self.error_code = error_code
+		self.message = CameraGetErrorString(error_code)
+
+	def __str__(self):
+		return 'error_code:{} message:{}'.format(self.error_code, self.message)
+
+class MvStructure(Structure):
+	def __str__(self):
+		strs = []
+		for field in self._fields_:
+			name = field[0]
+			value = getattr(self, name)
+			if isinstance(value, type(b'')):
+				value = _string_buffer_to_str(value)
+			strs.append("{}:{}".format(name, value))
+		return '\n'.join(strs)
+
+	def __repr__(self):
+		return self.__str__()
+
+	def clone(self):
+		obj = type(self)()
+		memmove(byref(obj), byref(self), sizeof(self))
+		return obj
+
+# 相机的设备信息，只读信息，请勿修改
+class tSdkCameraDevInfo(MvStructure):
+	_fields_ = [("acProductSeries", c_char * 32), #产品系列
+				("acProductName", c_char * 32), #产品名称
+				("acFriendlyName", c_char * 32), #产品昵称
+				("acLinkName", c_char * 32), #内核符号连接名，内部使用
+				("acDriverVersion", c_char * 32), #驱动版本
+				("acSensorType", c_char * 32), #sensor类型
+				("acPortType", c_char * 32), #接口类型
+				("acSn", c_char * 32), #产品唯一序列号
+				("uInstance", c_uint)] #该型号相机在该电脑上的实例索引号，用于区分同型号多相机
+
+	def GetProductSeries(self):
+		return _string_buffer_to_str(self.acProductSeries)
+	def GetProductName(self):
+		return _string_buffer_to_str(self.acProductName)
+	def GetFriendlyName(self):
+		return _string_buffer_to_str(self.acFriendlyName)
+	def GetLinkName(self):
+		return _string_buffer_to_str(self.acLinkName)
+	def GetDriverVersion(self):
+		return _string_buffer_to_str(self.acDriverVersion)
+	def GetSensorType(self):
+		return _string_buffer_to_str(self.acSensorType)
+	def GetPortType(self):
+		return _string_buffer_to_str(self.acPortType)
+	def GetSn(self):
+		return _string_buffer_to_str(self.acSn)
+
+# 相机的分辨率设定范围
+class tSdkResolutionRange(MvStructure):
+	_fields_ = [("iHeightMax", c_int), 	#图像最大高度
+				("iHeightMin", c_int), 	#图像最小高度
+				("iWidthMax", c_int), 	#图像最大宽度
+				("iWidthMin", c_int), 	#图像最小宽度
+				("uSkipModeMask", c_uint), 		#SKIP模式掩码，为0，表示不支持SKIP 。bit0为1,表示支持SKIP 2x2 bit1为1，表示支持SKIP 3x3....
+				("uBinSumModeMask", c_uint), 	#BIN(求和)模式掩码，为0，表示不支持BIN 。bit0为1,表示支持BIN 2x2 bit1为1，表示支持BIN 3x3....
+				("uBinAverageModeMask", c_uint),#BIN(求均值)模式掩码，为0，表示不支持BIN 。bit0为1,表示支持BIN 2x2 bit1为1，表示支持BIN 3x3....
+				("uResampleMask", c_uint)] 		#硬件重采样的掩码
+
+#相机的分辨率描述
+class tSdkImageResolution(MvStructure):
+	_fields_ = [
+		("iIndex", c_int),                # 索引号，[0,N]表示预设的分辨率(N 为预设分辨率的最大个数，一般不超过20),OXFF 表示自定义分辨率(ROI)
+		("acDescription", c_char * 32),   # 该分辨率的描述信息。仅预设分辨率时该信息有效。自定义分辨率可忽略该信息
+		("uBinSumMode", c_uint),          # BIN(求和)的模式,范围不能超过tSdkResolutionRange中uBinSumModeMask
+		("uBinAverageMode", c_uint),      # BIN(求均值)的模式,范围不能超过tSdkResolutionRange中uBinAverageModeMask
+		("uSkipMode", c_uint),            # 是否SKIP的尺寸，为0表示禁止SKIP模式，范围不能超过tSdkResolutionRange中uSkipModeMask
+		("uResampleMask", c_uint),        # 硬件重采样的掩码
+		("iHOffsetFOV", c_int),        # 采集视场相对于Sensor最大视场左上角的垂直偏移
+		("iVOffsetFOV", c_int),        # 采集视场相对于Sensor最大视场左上角的水平偏移
+		("iWidthFOV", c_int),          # 采集视场的宽度 
+		("iHeightFOV", c_int),         # 采集视场的高度
+		("iWidth", c_int),             # 相机最终输出的图像的宽度
+		("iHeight", c_int),            # 相机最终输出的图像的高度
+		("iWidthZoomHd", c_int),       # 硬件缩放的宽度,不需要进行此操作的分辨率，此变量设置为0.
+		("iHeightZoomHd", c_int),      # 硬件缩放的高度,不需要进行此操作的分辨率，此变量设置为0.
+		("iWidthZoomSw", c_int),       # 软件缩放的宽度,不需要进行此操作的分辨率，此变量设置为0.
+		("iHeightZoomSw", c_int),      # 软件缩放的高度,不需要进行此操作的分辨率，此变量设置为0.
+	]
+
+	def GetDescription(self):
+		return _string_buffer_to_str(self.acDescription)
+
+#相机白平衡模式描述信息
+class tSdkColorTemperatureDes(MvStructure):
+	_fields_ = [
+		("iIndex", c_int),				# 模式索引号
+		("acDescription", c_char * 32), # 描述信息
+	]
+
+	def GetDescription(self):
+		return _string_buffer_to_str(self.acDescription)
+
+#相机帧率描述信息
+class tSdkFrameSpeed(MvStructure):
+	_fields_ = [
+		("iIndex", c_int),				# 帧率索引号，一般0对应于低速模式，1对应于普通模式，2对应于高速模式      
+		("acDescription", c_char * 32), # 描述信息
+	]
+
+	def GetDescription(self):
+		return _string_buffer_to_str(self.acDescription)
+
+#相机曝光功能范围定义
+class tSdkExpose(MvStructure):
+	_fields_ = [
+		("uiTargetMin", c_uint),       #自动曝光亮度目标最小值
+		("uiTargetMax", c_uint),       #自动曝光亮度目标最大值
+		("uiAnalogGainMin", c_uint),   #模拟增益的最小值，单位为fAnalogGainStep中定义      
+		("uiAnalogGainMax", c_uint),   #模拟增益的最大值，单位为fAnalogGainStep中定义        
+		("fAnalogGainStep", c_float),  #模拟增益每增加1，对应的增加的放大倍数。例如，uiAnalogGainMin一般为16，fAnalogGainStep一般为0.125，那么最小放大倍数就是16*0.125 = 2倍
+		("uiExposeTimeMin", c_uint),   #手动模式下，曝光时间的最小值，单位:行。根据CameraGetExposureLineTime可以获得一行对应的时间(微秒),从而得到整帧的曝光时间    
+		("uiExposeTimeMax", c_uint),   #手动模式下，曝光时间的最大值，单位:行
+	]
+
+#触发模式描述
+class tSdkTrigger(MvStructure):
+	_fields_ = [
+		("iIndex", c_int),				# 模式索引号      
+		("acDescription", c_char * 32), # 描述信息
+	]
+
+	def GetDescription(self):
+		return _string_buffer_to_str(self.acDescription)
+
+#传输分包大小描述(主要是针对网络相机有效)
+class tSdkPackLength(MvStructure):
+	_fields_ = [
+		("iIndex", c_int),				# 模式索引号      
+		("acDescription", c_char * 32), # 描述信息
+		("iPackSize", c_uint),
+	]
+
+	def GetDescription(self):
+		return _string_buffer_to_str(self.acDescription)
+
+#预设的LUT表描述
+class tSdkPresetLut(MvStructure):
+	_fields_ = [
+		("iIndex", c_int),				# 编号
+		("acDescription", c_char * 32), # 描述信息
+	]
+
+	def GetDescription(self):
+		return _string_buffer_to_str(self.acDescription)
+
+#AE算法描述
+class tSdkAeAlgorithm(MvStructure):
+	_fields_ = [
+		("iIndex", c_int),				# 编号
+		("acDescription", c_char * 32), # 描述信息
+	]
+
+	def GetDescription(self):
+		return _string_buffer_to_str(self.acDescription)
+
+#RAW转RGB算法描述
+class tSdkBayerDecodeAlgorithm(MvStructure):
+	_fields_ = [
+		("iIndex", c_int),				# 编号
+		("acDescription", c_char * 32), # 描述信息
+	]
+
+	def GetDescription(self):
+		return _string_buffer_to_str(self.acDescription)
+
+#帧率统计信息
+class tSdkFrameStatistic(MvStructure):
+	_fields_ = [
+		("iTotal", c_int),        #当前采集的总帧数（包括错误帧）
+		("iCapture", c_int),      #当前采集的有效帧的数量    
+		("iLost", c_int),         #当前丢帧的数量    
+	]
+
+#相机输出的图像数据格式
+class tSdkMediaType(MvStructure):
+	_fields_ = [
+		("iIndex", c_int),				# 格式种类编号
+		("acDescription", c_char * 32), # 描述信息
+		("iMediaType", c_uint),			# 对应的图像格式编码，如CAMERA_MEDIA_TYPE_BAYGR8。
+	]
+
+	def GetDescription(self):
+		return _string_buffer_to_str(self.acDescription)
+
+#伽马的设定范围
+class tGammaRange(MvStructure):
+	_fields_ = [
+		("iMin", c_int),       #最小值
+		("iMax", c_int),       #最大值
+	]
+
+#对比度的设定范围
+class tContrastRange(MvStructure):
+	_fields_ = [
+		("iMin", c_int),       #最小值
+		("iMax", c_int),       #最大值
+	]
+
+#RGB三通道数字增益的设定范围
+class tRgbGainRange(MvStructure):
+	_fields_ = [
+		("iRGainMin", c_int),   #红色增益的最小值
+		("iRGainMax", c_int),   #红色增益的最大值
+		("iGGainMin", c_int),   #绿色增益的最小值
+		("iGGainMax", c_int),   #绿色增益的最大值
+		("iBGainMin", c_int),   #蓝色增益的最小值
+		("iBGainMax", c_int),   #蓝色增益的最大值
+	]
+
+#饱和度设定的范围
+class tSaturationRange(MvStructure):
+	_fields_ = [
+		("iMin", c_int),       #最小值
+		("iMax", c_int),       #最大值
+	]
+
+#锐化的设定范围
+class tSharpnessRange(MvStructure):
+	_fields_ = [
+		("iMin", c_int),       #最小值
+		("iMax", c_int),       #最大值
+	]
+
+#ISP模块的使能信息
+class tSdkIspCapacity(MvStructure):
+	_fields_ = [
+		("bMonoSensor", c_int),        #表示该型号相机是否为黑白相机,如果是黑白相机，则颜色相关的功能都无法调节
+		("bWbOnce", c_int),            #表示该型号相机是否支持手动白平衡功能  
+		("bAutoWb", c_int),            #表示该型号相机是否支持自动白平衡功能
+		("bAutoExposure", c_int),      #表示该型号相机是否支持自动曝光功能
+		("bManualExposure", c_int),    #表示该型号相机是否支持手动曝光功能
+		("bAntiFlick", c_int),         #表示该型号相机是否支持抗频闪功能
+		("bDeviceIsp", c_int),         #表示该型号相机是否支持硬件ISP功能
+		("bForceUseDeviceIsp", c_int), #bDeviceIsp和bForceUseDeviceIsp同时为TRUE时，表示强制只用硬件ISP，不可取消。
+		("bZoomHD", c_int),            #相机硬件是否支持图像缩放输出(只能是缩小)。
+	]
+
+# 定义整合的设备描述信息，这些信息可以用于动态构建UI
+class tSdkCameraCapbility(MvStructure):
+	_fields_ = [
+		("pTriggerDesc", POINTER(tSdkTrigger)),
+		("iTriggerDesc", c_int),	#触发模式的个数，即pTriggerDesc数组的大小
+		("pImageSizeDesc", POINTER(tSdkImageResolution)),
+		("iImageSizeDesc", c_int),	#预设分辨率的个数，即pImageSizeDesc数组的大小 
+		("pClrTempDesc", POINTER(tSdkColorTemperatureDes)),
+		("iClrTempDesc", c_int),	#预设色温个数
+		("pMediaTypeDesc", POINTER(tSdkMediaType)),
+		("iMediaTypeDesc", c_int),	#相机输出图像格式的种类个数，即pMediaTypeDesc数组的大小。
+		("pFrameSpeedDesc", POINTER(tSdkFrameSpeed)), #可调节帧速类型，对应界面上普通 高速 和超级三种速度设置
+		("iFrameSpeedDesc", c_int), #可调节帧速类型的个数，即pFrameSpeedDesc数组的大小。
+		("pPackLenDesc", POINTER(tSdkPackLength)), #传输包长度，一般用于网络设备
+		("iPackLenDesc", c_int), #可供选择的传输分包长度的个数，即pPackLenDesc数组的大小。 
+		("iOutputIoCounts", c_int),        #可编程输出IO的个数
+		("iInputIoCounts", c_int),         #可编程输入IO的个数
+		("pPresetLutDesc", POINTER(tSdkPresetLut)), #相机预设的LUT表
+		("iPresetLut", c_int),             #相机预设的LUT表的个数，即pPresetLutDesc数组的大小
+		("iUserDataMaxLen", c_int),        #指示该相机中用于保存用户数据区的最大长度。为0表示无。
+		("bParamInDevice", c_int),         #指示该设备是否支持从设备中读写参数组。1为支持，0不支持。
+		("pAeAlmSwDesc", POINTER(tSdkAeAlgorithm)),#软件自动曝光算法描述
+		("iAeAlmSwDesc", c_int),           #软件自动曝光算法个数
+		("pAeAlmHdDesc", POINTER(tSdkAeAlgorithm)),#硬件自动曝光算法描述，为NULL表示不支持硬件自动曝光
+		("iAeAlmHdDesc", c_int),           #硬件自动曝光算法个数，为0表示不支持硬件自动曝光
+		("pBayerDecAlmSwDesc", POINTER(tSdkBayerDecodeAlgorithm)),#软件Bayer转换为RGB数据的算法描述
+		("iBayerDecAlmSwDesc", c_int),     #软件Bayer转换为RGB数据的算法个数
+		("pBayerDecAlmHdDesc", POINTER(tSdkBayerDecodeAlgorithm)),#硬件Bayer转换为RGB数据的算法描述，为NULL表示不支持
+		("iBayerDecAlmHdDesc", c_int),     #硬件Bayer转换为RGB数据的算法个数，为0表示不支持
+
+		# 图像参数的调节范围定义,用于动态构建UI
+		("sExposeDesc", tSdkExpose),      #曝光的范围值
+		("sResolutionRange", tSdkResolutionRange), #分辨率范围描述  
+		("sRgbGainRange", tRgbGainRange),    #图像数字增益范围描述  
+		("sSaturationRange", tSaturationRange), #饱和度范围描述  
+		("sGammaRange", tGammaRange),      #伽马范围描述  
+		("sContrastRange", tContrastRange),   #对比度范围描述  
+		("sSharpnessRange", tSharpnessRange),  #锐化范围描述  
+		("sIspCapacity", tSdkIspCapacity),     #ISP能力描述
+	]
+
+#图像帧头信息
+class tSdkFrameHead(MvStructure):
+	_fields_ = [
+		("uiMediaType", c_uint),      # 图像格式,Image Format
+		("uBytes", c_uint),           # 图像数据字节数,Total bytes
+		("iWidth", c_int),            # 宽度 Image height
+		("iHeight", c_int),           # 高度 Image width
+		("iWidthZoomSw", c_int),      # 软件缩放的宽度,不需要进行软件裁剪的图像，此变量设置为0.
+		("iHeightZoomSw", c_int),     # 软件缩放的高度,不需要进行软件裁剪的图像，此变量设置为0.
+		("bIsTrigger", c_int),        # 指示是否为触发帧 is trigger 
+		("uiTimeStamp", c_uint),      # 该帧的采集时间，单位0.1毫秒 
+		("uiExpTime", c_uint),        # 当前图像的曝光值，单位为微秒us
+		("fAnalogGain", c_float),     # 当前图像的模拟增益倍数
+		("iGamma", c_int),            # 该帧图像的伽马设定值，仅当LUT模式为动态参数生成时有效，其余模式下为-1
+		("iContrast", c_int),         # 该帧图像的对比度设定值，仅当LUT模式为动态参数生成时有效，其余模式下为-1
+		("iSaturation", c_int),       # 该帧图像的饱和度设定值，对于黑白相机无意义，为0
+		("fRgain", c_float),          # 该帧图像处理的红色数字增益倍数，对于黑白相机无意义，为1
+		("fGgain", c_float),          # 该帧图像处理的绿色数字增益倍数，对于黑白相机无意义，为1
+		("fBgain", c_float),          # 该帧图像处理的蓝色数字增益倍数，对于黑白相机无意义，为1
+	]
+
+# Grabber统计信息
+class tSdkGrabberStat(MvStructure):
+	_fields_ = [
+		("Width", c_int),           # 帧图像大小
+		("Height", c_int),	        # 帧图像大小
+		("Disp", c_int),			# 显示帧数量
+		("Capture", c_int),		    # 采集的有效帧的数量
+		("Lost", c_int),			# 丢帧的数量
+		("Error", c_int),			# 错帧的数量
+		("DispFps", c_float),		# 显示帧率
+		("CapFps", c_float),		# 捕获帧率
+	]
+
+# 方法回调辅助类
+class method(object):
+	def __init__(self, FuncType):
+		super(method, self).__init__()
+		self.FuncType = FuncType
+		self.cache = {}
+
+	def __call__(self, cb):
+		self.cb = cb
+		return self
+
+	def __get__(self, obj, objtype):
+		try:
+			return self.cache[obj]
+		except KeyError as e:
+			def cl(*args):
+				return self.cb(obj, *args)
+			r = self.cache[obj] = self.FuncType(cl)
+			return r
+
+# 图像捕获的回调函数定义
+CAMERA_SNAP_PROC = CALLBACK_FUNC_TYPE(None, c_int, c_void_p, POINTER(tSdkFrameHead), c_void_p)
+
+# 相机连接状态回调
+CAMERA_CONNECTION_STATUS_CALLBACK = CALLBACK_FUNC_TYPE(None, c_int, c_uint, c_uint, c_void_p)
+
+# 异步抓图完成回调
+pfnCameraGrabberSaveImageComplete = CALLBACK_FUNC_TYPE(None, c_void_p, c_void_p, c_int, c_void_p)
+
+# 帧监听回调
+pfnCameraGrabberFrameListener = CALLBACK_FUNC_TYPE(c_int, c_void_p, c_int, c_void_p, POINTER(tSdkFrameHead), c_void_p)
+
+# 采集器图像捕获的回调
+pfnCameraGrabberFrameCallback = CALLBACK_FUNC_TYPE(None, c_void_p, c_void_p, POINTER(tSdkFrameHead), c_void_p)
+
+#-----------------------------------函数接口------------------------------------------
+
+# 线程局部存储
+_tls = local()
+
+# 存储最后一次SDK调用返回的错误码
+def GetLastError():
+	try:
+		return _tls.last_error
+	except AttributeError as e:
+		_tls.last_error = 0
+		return 0
+
+def SetLastError(err_code):
+	_tls.last_error = err_code
+
+def _string_buffer_to_str(buf):
+	s = buf if isinstance(buf, type(b'')) else buf.value
+
+	for codec in ('gbk', 'utf-8'):
+		try:
+			s = s.decode(codec)
+			break
+		except UnicodeDecodeError as e:
+			continue
+
+	if isinstance(s, str):
+		return s
+	else:
+		return s.encode('utf-8')
+
+def _str_to_string_buffer(str):
+	if type(str) is type(u''):
+		s = str.encode('gbk')
+	else:
+		s = str.decode('utf-8').encode('gbk')
+	return create_string_buffer(s)
+
+def CameraSdkInit(iLanguageSel):
+	err_code = _sdk.CameraSdkInit(iLanguageSel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraEnumerateDevice(MaxCount = 32):
+	Nums = c_int(MaxCount)
+	pCameraList = (tSdkCameraDevInfo * Nums.value)()
+	err_code = _sdk.CameraEnumerateDevice(pCameraList, byref(Nums))
+	SetLastError(err_code)
+	return pCameraList[0:Nums.value]
+
+def CameraEnumerateDeviceEx():
+	return _sdk.CameraEnumerateDeviceEx()
+
+def CameraIsOpened(pCameraInfo):
+	pOpened = c_int()
+	err_code = _sdk.CameraIsOpened(byref(pCameraInfo), byref(pOpened) )
+	SetLastError(err_code)
+	return pOpened.value != 0
+
+def CameraInit(pCameraInfo, emParamLoadMode = -1, emTeam = -1):
+	pCameraHandle = c_int()
+	err_code = _sdk.CameraInit(byref(pCameraInfo), emParamLoadMode, emTeam, byref(pCameraHandle))
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return pCameraHandle.value
+
+def CameraInitEx(iDeviceIndex, emParamLoadMode = -1, emTeam = -1):
+	pCameraHandle = c_int()
+	err_code = _sdk.CameraInitEx(iDeviceIndex, emParamLoadMode, emTeam, byref(pCameraHandle))
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return pCameraHandle.value
+
+def CameraInitEx2(CameraName):
+	pCameraHandle = c_int()
+	err_code = _sdk.CameraInitEx2(_str_to_string_buffer(CameraName), byref(pCameraHandle))
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return pCameraHandle.value
+
+def CameraSetCallbackFunction(hCamera, pCallBack, pContext = 0):
+	err_code = _sdk.CameraSetCallbackFunction(hCamera, pCallBack, c_void_p(pContext), None)
+	SetLastError(err_code)
+	return err_code
+
+def CameraUnInit(hCamera):
+	err_code = _sdk.CameraUnInit(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetInformation(hCamera):
+	pbuffer = c_char_p()
+	err_code = _sdk.CameraGetInformation(hCamera, byref(pbuffer) )
+	SetLastError(err_code)
+	if err_code == 0 and pbuffer.value is not None:
+		return _string_buffer_to_str(pbuffer)
+	return ''
+
+def CameraImageProcess(hCamera, pbyIn, pbyOut, pFrInfo):
+	err_code = _sdk.CameraImageProcess(hCamera, c_void_p(pbyIn), c_void_p(pbyOut), byref(pFrInfo))
+	SetLastError(err_code)
+	return err_code
+
+def CameraImageProcessEx(hCamera, pbyIn, pbyOut, pFrInfo, uOutFormat, uReserved):
+	err_code = _sdk.CameraImageProcessEx(hCamera, c_void_p(pbyIn), c_void_p(pbyOut), byref(pFrInfo), uOutFormat, uReserved)
+	SetLastError(err_code)
+	return err_code
+
+def CameraDisplayInit(hCamera, hWndDisplay):
+	err_code = _sdk.CameraDisplayInit(hCamera, hWndDisplay)
+	SetLastError(err_code)
+	return err_code
+
+def CameraDisplayRGB24(hCamera, pFrameBuffer, pFrInfo):
+	err_code = _sdk.CameraDisplayRGB24(hCamera, c_void_p(pFrameBuffer), byref(pFrInfo) )
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetDisplayMode(hCamera, iMode):
+	err_code = _sdk.CameraSetDisplayMode(hCamera, iMode)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetDisplayOffset(hCamera, iOffsetX, iOffsetY):
+	err_code = _sdk.CameraSetDisplayOffset(hCamera, iOffsetX, iOffsetY)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetDisplaySize(hCamera, iWidth, iHeight):
+	err_code = _sdk.CameraSetDisplaySize(hCamera, iWidth, iHeight)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetImageBuffer(hCamera, wTimes):
+	pbyBuffer = c_void_p()
+	pFrameInfo = tSdkFrameHead()
+	err_code = _sdk.CameraGetImageBuffer(hCamera, byref(pFrameInfo), byref(pbyBuffer), wTimes)
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return (pbyBuffer.value, pFrameInfo)
+
+def CameraGetImageBufferEx(hCamera, wTimes):
+	_sdk.CameraGetImageBufferEx.restype = c_void_p
+	piWidth = c_int()
+	piHeight = c_int()
+	pFrameBuffer = _sdk.CameraGetImageBufferEx(hCamera, byref(piWidth), byref(piHeight), wTimes)
+	err_code = CAMERA_STATUS_SUCCESS if pFrameBuffer else CAMERA_STATUS_TIME_OUT
+	SetLastError(err_code)
+	if pFrameBuffer:
+		return (pFrameBuffer, piWidth.value, piHeight.value)
+	else:
+		raise CameraException(err_code)
+
+def CameraSnapToBuffer(hCamera, wTimes):
+	pbyBuffer = c_void_p()
+	pFrameInfo = tSdkFrameHead()
+	err_code = _sdk.CameraSnapToBuffer(hCamera, byref(pFrameInfo), byref(pbyBuffer), wTimes)
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return (pbyBuffer.value, pFrameInfo)
+
+def CameraReleaseImageBuffer(hCamera, pbyBuffer):
+	err_code = _sdk.CameraReleaseImageBuffer(hCamera, c_void_p(pbyBuffer) )
+	SetLastError(err_code)
+	return err_code
+
+def CameraPlay(hCamera):
+	err_code = _sdk.CameraPlay(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraPause(hCamera):
+	err_code = _sdk.CameraPause(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraStop(hCamera):
+	err_code = _sdk.CameraStop(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraInitRecord(hCamera, iFormat, pcSavePath, b2GLimit, dwQuality, iFrameRate):
+	err_code = _sdk.CameraInitRecord(hCamera, iFormat, _str_to_string_buffer(pcSavePath), b2GLimit, dwQuality, iFrameRate)
+	SetLastError(err_code)
+	return err_code
+
+def CameraStopRecord(hCamera):
+	err_code = _sdk.CameraStopRecord(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraPushFrame(hCamera, pbyImageBuffer, pFrInfo):
+	err_code = _sdk.CameraPushFrame(hCamera, c_void_p(pbyImageBuffer), byref(pFrInfo) )
+	SetLastError(err_code)
+	return err_code
+
+def CameraSaveImage(hCamera, lpszFileName, pbyImageBuffer, pFrInfo, byFileType, byQuality):
+	err_code = _sdk.CameraSaveImage(hCamera, _str_to_string_buffer(lpszFileName), c_void_p(pbyImageBuffer), byref(pFrInfo), byFileType, byQuality)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSaveImageEx(hCamera, lpszFileName, pbyImageBuffer, uImageFormat, iWidth, iHeight, byFileType, byQuality):
+	err_code = _sdk.CameraSaveImageEx(hCamera, _str_to_string_buffer(lpszFileName), c_void_p(pbyImageBuffer), uImageFormat, iWidth, iHeight, byFileType, byQuality)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetImageResolution(hCamera):
+	psCurVideoSize = tSdkImageResolution()
+	err_code = _sdk.CameraGetImageResolution(hCamera, byref(psCurVideoSize) )
+	SetLastError(err_code)
+	return psCurVideoSize
+
+def CameraSetImageResolution(hCamera, pImageResolution):
+	err_code = _sdk.CameraSetImageResolution(hCamera, byref(pImageResolution) )
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetImageResolutionEx(hCamera, iIndex, Mode, ModeSize, x, y, width, height, ZoomWidth, ZoomHeight):
+	err_code = _sdk.CameraSetImageResolutionEx(hCamera, iIndex, Mode, ModeSize, x, y, width, height, ZoomWidth, ZoomHeight)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetMediaType(hCamera):
+	piMediaType = c_int()
+	err_code = _sdk.CameraGetMediaType(hCamera, byref(piMediaType) )
+	SetLastError(err_code)
+	return piMediaType.value
+
+def CameraSetMediaType(hCamera, iMediaType):
+	err_code = _sdk.CameraSetMediaType(hCamera, iMediaType)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetAeState(hCamera, bAeState):
+	err_code = _sdk.CameraSetAeState(hCamera, bAeState)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAeState(hCamera):
+	pAeState = c_int()
+	err_code = _sdk.CameraGetAeState(hCamera, byref(pAeState) )
+	SetLastError(err_code)
+	return pAeState.value
+
+def CameraSetSharpness(hCamera, iSharpness):
+	err_code = _sdk.CameraSetSharpness(hCamera, iSharpness)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetSharpness(hCamera):
+	piSharpness = c_int()
+	err_code = _sdk.CameraGetSharpness(hCamera, byref(piSharpness) )
+	SetLastError(err_code)
+	return piSharpness.value
+
+def CameraSetLutMode(hCamera, emLutMode):
+	err_code = _sdk.CameraSetLutMode(hCamera, emLutMode)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetLutMode(hCamera):
+	pemLutMode = c_int()
+	err_code = _sdk.CameraGetLutMode(hCamera, byref(pemLutMode) )
+	SetLastError(err_code)
+	return pemLutMode.value
+
+def CameraSelectLutPreset(hCamera, iSel):
+	err_code = _sdk.CameraSelectLutPreset(hCamera, iSel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetLutPresetSel(hCamera):
+	piSel = c_int()
+	err_code = _sdk.CameraGetLutPresetSel(hCamera, byref(piSel) )
+	SetLastError(err_code)
+	return piSel.value
+
+def CameraSetCustomLut(hCamera, iChannel, pLut):
+	pLutNative = (c_ushort * 4096)(*pLut)
+	err_code = _sdk.CameraSetCustomLut(hCamera, iChannel, pLutNative)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetCustomLut(hCamera, iChannel):
+	pLutNative = (c_ushort * 4096)()
+	err_code = _sdk.CameraGetCustomLut(hCamera, iChannel, pLutNative)
+	SetLastError(err_code)
+	return pLutNative[:]
+
+def CameraGetCurrentLut(hCamera, iChannel):
+	pLutNative = (c_ushort * 4096)()
+	err_code = _sdk.CameraGetCurrentLut(hCamera, iChannel, pLutNative)
+	SetLastError(err_code)
+	return pLutNative[:]
+
+def CameraSetWbMode(hCamera, bAuto):
+	err_code = _sdk.CameraSetWbMode(hCamera, bAuto)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetWbMode(hCamera):
+	pbAuto = c_int()
+	err_code = _sdk.CameraGetWbMode(hCamera, byref(pbAuto) )
+	SetLastError(err_code)
+	return pbAuto.value
+
+def CameraSetPresetClrTemp(hCamera, iSel):
+	err_code = _sdk.CameraSetPresetClrTemp(hCamera, iSel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetPresetClrTemp(hCamera):
+	piSel = c_int()
+	err_code = _sdk.CameraGetPresetClrTemp(hCamera, byref(piSel) )
+	SetLastError(err_code)
+	return piSel.value
+
+def CameraSetUserClrTempGain(hCamera, iRgain, iGgain, iBgain):
+	err_code = _sdk.CameraSetUserClrTempGain(hCamera, iRgain, iGgain, iBgain)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetUserClrTempGain(hCamera):
+	piRgain = c_int()
+	piGgain = c_int()
+	piBgain = c_int()
+	err_code = _sdk.CameraGetUserClrTempGain(hCamera, byref(piRgain), byref(piGgain), byref(piBgain) )
+	SetLastError(err_code)
+	return (piRgain.value, piGgain.value, piBgain.value)
+
+def CameraSetUserClrTempMatrix(hCamera, pMatrix):
+	pMatrixNative = (c_float * 9)(*pMatrix)
+	err_code = _sdk.CameraSetUserClrTempMatrix(hCamera, pMatrixNative)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetUserClrTempMatrix(hCamera):
+	pMatrixNative = (c_float * 9)()
+	err_code = _sdk.CameraGetUserClrTempMatrix(hCamera, pMatrixNative)
+	SetLastError(err_code)
+	return pMatrixNative[:]
+
+def CameraSetClrTempMode(hCamera, iMode):
+	err_code = _sdk.CameraSetClrTempMode(hCamera, iMode)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetClrTempMode(hCamera):
+	piMode = c_int()
+	err_code = _sdk.CameraGetClrTempMode(hCamera, byref(piMode) )
+	SetLastError(err_code)
+	return piMode.value
+
+def CameraSetOnceWB(hCamera):
+	err_code = _sdk.CameraSetOnceWB(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetOnceBB(hCamera):
+	err_code = _sdk.CameraSetOnceBB(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetAeTarget(hCamera, iAeTarget):
+	err_code = _sdk.CameraSetAeTarget(hCamera, iAeTarget)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAeTarget(hCamera):
+	piAeTarget = c_int()
+	err_code = _sdk.CameraGetAeTarget(hCamera, byref(piAeTarget) )
+	SetLastError(err_code)
+	return piAeTarget.value
+
+def CameraSetAeExposureRange(hCamera, fMinExposureTime, fMaxExposureTime):
+	err_code = _sdk.CameraSetAeExposureRange(hCamera, c_double(fMinExposureTime), c_double(fMaxExposureTime) )
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAeExposureRange(hCamera):
+	fMinExposureTime = c_double()
+	fMaxExposureTime = c_double()
+	err_code = _sdk.CameraGetAeExposureRange(hCamera, byref(fMinExposureTime), byref(fMaxExposureTime) )
+	SetLastError(err_code)
+	return (fMinExposureTime.value, fMaxExposureTime.value)
+
+def CameraSetAeAnalogGainRange(hCamera, iMinAnalogGain, iMaxAnalogGain):
+	err_code = _sdk.CameraSetAeAnalogGainRange(hCamera, iMinAnalogGain, iMaxAnalogGain)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAeAnalogGainRange(hCamera):
+	iMinAnalogGain = c_int()
+	iMaxAnalogGain = c_int()
+	err_code = _sdk.CameraGetAeAnalogGainRange(hCamera, byref(iMinAnalogGain), byref(iMaxAnalogGain) )
+	SetLastError(err_code)
+	return (iMinAnalogGain.value, iMaxAnalogGain.value)
+
+def CameraSetAeThreshold(hCamera, iThreshold):
+	err_code = _sdk.CameraSetAeThreshold(hCamera, iThreshold)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAeThreshold(hCamera):
+	iThreshold = c_int()
+	err_code = _sdk.CameraGetAeThreshold(hCamera, byref(iThreshold))
+	SetLastError(err_code)
+	return iThreshold.value
+
+def CameraSetExposureTime(hCamera, fExposureTime):
+	err_code = _sdk.CameraSetExposureTime(hCamera, c_double(fExposureTime) )
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetExposureLineTime(hCamera):
+	pfLineTime = c_double()
+	err_code = _sdk.CameraGetExposureLineTime(hCamera, byref(pfLineTime))
+	SetLastError(err_code)
+	return pfLineTime.value
+
+def CameraGetExposureTime(hCamera):
+	pfExposureTime = c_double()
+	err_code = _sdk.CameraGetExposureTime(hCamera, byref(pfExposureTime))
+	SetLastError(err_code)
+	return pfExposureTime.value
+
+def CameraGetExposureTimeRange(hCamera):
+	pfMin = c_double()
+	pfMax = c_double()
+	pfStep = c_double()
+	err_code = _sdk.CameraGetExposureTimeRange(hCamera, byref(pfMin), byref(pfMax), byref(pfStep))
+	SetLastError(err_code)
+	return (pfMin.value, pfMax.value, pfStep.value)
+
+def CameraSetAnalogGain(hCamera, iAnalogGain):
+	err_code = _sdk.CameraSetAnalogGain(hCamera, iAnalogGain)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAnalogGain(hCamera):
+	piAnalogGain = c_int()
+	err_code = _sdk.CameraGetAnalogGain(hCamera, byref(piAnalogGain))
+	SetLastError(err_code)
+	return piAnalogGain.value
+
+def CameraSetGain(hCamera, iRGain, iGGain, iBGain):
+	err_code = _sdk.CameraSetGain(hCamera, iRGain, iGGain, iBGain)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetGain(hCamera):
+	piRGain = c_int()
+	piGGain = c_int()
+	piBGain = c_int()
+	err_code = _sdk.CameraGetGain(hCamera, byref(piRGain), byref(piGGain), byref(piBGain))
+	SetLastError(err_code)
+	return (piRGain.value, piGGain.value, piBGain.value)
+
+def CameraSetGamma(hCamera, iGamma):
+	err_code = _sdk.CameraSetGamma(hCamera, iGamma)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetGamma(hCamera):
+	piGamma = c_int()
+	err_code = _sdk.CameraGetGamma(hCamera, byref(piGamma))
+	SetLastError(err_code)
+	return piGamma.value
+
+def CameraSetContrast(hCamera, iContrast):
+	err_code = _sdk.CameraSetContrast(hCamera, iContrast)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetContrast(hCamera):
+	piContrast = c_int()
+	err_code = _sdk.CameraGetContrast(hCamera, byref(piContrast))
+	SetLastError(err_code)
+	return piContrast.value
+
+def CameraSetSaturation(hCamera, iSaturation):
+	err_code = _sdk.CameraSetSaturation(hCamera, iSaturation)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetSaturation(hCamera):
+	piSaturation = c_int()
+	err_code = _sdk.CameraGetSaturation(hCamera, byref(piSaturation))
+	SetLastError(err_code)
+	return piSaturation.value
+
+def CameraSetMonochrome(hCamera, bEnable):
+	err_code = _sdk.CameraSetMonochrome(hCamera, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetMonochrome(hCamera):
+	pbEnable = c_int()
+	err_code = _sdk.CameraGetMonochrome(hCamera, byref(pbEnable))
+	SetLastError(err_code)
+	return pbEnable.value
+
+def CameraSetInverse(hCamera, bEnable):
+	err_code = _sdk.CameraSetInverse(hCamera, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetInverse(hCamera):
+	pbEnable = c_int()
+	err_code = _sdk.CameraGetInverse(hCamera, byref(pbEnable))
+	SetLastError(err_code)
+	return pbEnable.value
+
+def CameraSetAntiFlick(hCamera, bEnable):
+	err_code = _sdk.CameraSetAntiFlick(hCamera, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAntiFlick(hCamera):
+	pbEnable = c_int()
+	err_code = _sdk.CameraGetAntiFlick(hCamera, byref(pbEnable))
+	SetLastError(err_code)
+	return pbEnable.value
+
+def CameraGetLightFrequency(hCamera):
+	piFrequencySel = c_int()
+	err_code = _sdk.CameraGetLightFrequency(hCamera, byref(piFrequencySel))
+	SetLastError(err_code)
+	return piFrequencySel.value
+
+def CameraSetLightFrequency(hCamera, iFrequencySel):
+	err_code = _sdk.CameraSetLightFrequency(hCamera, iFrequencySel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetFrameSpeed(hCamera, iFrameSpeed):
+	err_code = _sdk.CameraSetFrameSpeed(hCamera, iFrameSpeed)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetFrameSpeed(hCamera):
+	piFrameSpeed = c_int()
+	err_code = _sdk.CameraGetFrameSpeed(hCamera, byref(piFrameSpeed))
+	SetLastError(err_code)
+	return piFrameSpeed.value
+
+def CameraSetParameterMode(hCamera, iMode):
+	err_code = _sdk.CameraSetParameterMode(hCamera, iMode)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetParameterMode(hCamera):
+	piTarget = c_int()
+	err_code = _sdk.CameraGetParameterMode(hCamera, byref(piTarget))
+	SetLastError(err_code)
+	return piTarget.value
+
+def CameraSetParameterMask(hCamera, uMask):
+	err_code = _sdk.CameraSetParameterMask(hCamera, uMask)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSaveParameter(hCamera, iTeam):
+	err_code = _sdk.CameraSaveParameter(hCamera, iTeam)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSaveParameterToFile(hCamera, sFileName):
+	err_code = _sdk.CameraSaveParameterToFile(hCamera, _str_to_string_buffer(sFileName))
+	SetLastError(err_code)
+	return err_code
+
+def CameraReadParameterFromFile(hCamera, sFileName):
+	err_code = _sdk.CameraReadParameterFromFile(hCamera, _str_to_string_buffer(sFileName))
+	SetLastError(err_code)
+	return err_code
+
+def CameraLoadParameter(hCamera, iTeam):
+	err_code = _sdk.CameraLoadParameter(hCamera, iTeam)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetCurrentParameterGroup(hCamera):
+	piTeam = c_int()
+	err_code = _sdk.CameraGetCurrentParameterGroup(hCamera, byref(piTeam))
+	SetLastError(err_code)
+	return piTeam.value
+
+def CameraSetTransPackLen(hCamera, iPackSel):
+	err_code = _sdk.CameraSetTransPackLen(hCamera, iPackSel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetTransPackLen(hCamera):
+	piPackSel = c_int()
+	err_code = _sdk.CameraGetTransPackLen(hCamera, byref(piPackSel))
+	SetLastError(err_code)
+	return piPackSel.value
+
+def CameraIsAeWinVisible(hCamera):
+	pbIsVisible = c_int()
+	err_code = _sdk.CameraIsAeWinVisible(hCamera, byref(pbIsVisible))
+	SetLastError(err_code)
+	return pbIsVisible.value
+
+def CameraSetAeWinVisible(hCamera, bIsVisible):
+	err_code = _sdk.CameraSetAeWinVisible(hCamera, bIsVisible)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAeWindow(hCamera):
+	piHOff = c_int()
+	piVOff = c_int()
+	piWidth = c_int()
+	piHeight = c_int()
+	err_code = _sdk.CameraGetAeWindow(hCamera, byref(piHOff), byref(piVOff), byref(piWidth), byref(piHeight))
+	SetLastError(err_code)
+	return (piHOff.value, piVOff.value, piWidth.value, piHeight.value)
+
+def CameraSetAeWindow(hCamera, iHOff, iVOff, iWidth, iHeight):
+	err_code = _sdk.CameraSetAeWindow(hCamera, iHOff, iVOff, iWidth, iHeight)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetMirror(hCamera, iDir, bEnable):
+	err_code = _sdk.CameraSetMirror(hCamera, iDir, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetMirror(hCamera, iDir):
+	pbEnable = c_int()
+	err_code = _sdk.CameraGetMirror(hCamera, iDir, byref(pbEnable))
+	SetLastError(err_code)
+	return pbEnable.value
+
+def CameraSetRotate(hCamera, iRot):
+	err_code = _sdk.CameraSetRotate(hCamera, iRot)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetRotate(hCamera):
+	iRot = c_int()
+	err_code = _sdk.CameraGetRotate(hCamera, byref(iRot))
+	SetLastError(err_code)
+	return iRot.value
+
+def CameraGetWbWindow(hCamera):
+	PiHOff = c_int()
+	PiVOff = c_int()
+	PiWidth = c_int()
+	PiHeight = c_int()
+	err_code = _sdk.CameraGetWbWindow(hCamera, byref(PiHOff), byref(PiVOff), byref(PiWidth), byref(PiHeight))
+	SetLastError(err_code)
+	return (PiHOff.value, PiVOff.value, PiWidth.value, PiHeight.value)
+
+def CameraSetWbWindow(hCamera, iHOff, iVOff, iWidth, iHeight):
+	err_code = _sdk.CameraSetWbWindow(hCamera, iHOff, iVOff, iWidth, iHeight)
+	SetLastError(err_code)
+	return err_code
+
+def CameraIsWbWinVisible(hCamera):
+	pbShow = c_int()
+	err_code = _sdk.CameraIsWbWinVisible(hCamera, byref(pbShow))
+	SetLastError(err_code)
+	return pbShow.value
+
+def CameraSetWbWinVisible(hCamera, bShow):
+	err_code = _sdk.CameraSetWbWinVisible(hCamera, bShow)
+	SetLastError(err_code)
+	return err_code
+
+def CameraImageOverlay(hCamera, pRgbBuffer, pFrInfo):
+	err_code = _sdk.CameraImageOverlay(hCamera, c_void_p(pRgbBuffer), byref(pFrInfo))
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetCrossLine(hCamera, iLine, x, y, uColor, bVisible):
+	err_code = _sdk.CameraSetCrossLine(hCamera, iLine, x, y, uColor, bVisible)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetCrossLine(hCamera, iLine):
+	px = c_int()
+	py = c_int()
+	pcolor = c_uint()
+	pbVisible = c_int()
+	err_code = _sdk.CameraGetCrossLine(hCamera, iLine, byref(px), byref(py), byref(pcolor), byref(pbVisible))
+	SetLastError(err_code)
+	return (px.value, py.value, pcolor.value, pbVisible.value)
+
+def CameraGetCapability(hCamera):
+	pCameraInfo = tSdkCameraCapbility()
+	err_code = _sdk.CameraGetCapability(hCamera, byref(pCameraInfo))
+	SetLastError(err_code)
+	return pCameraInfo
+
+def CameraWriteSN(hCamera, pbySN, iLevel):
+	err_code = _sdk.CameraWriteSN(hCamera, _str_to_string_buffer(pbySN), iLevel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraReadSN(hCamera, iLevel):
+	pbySN = create_string_buffer(64)
+	err_code = _sdk.CameraReadSN(hCamera, pbySN, iLevel)
+	SetLastError(err_code)
+	return _string_buffer_to_str(pbySN)
+
+def CameraSetTriggerDelayTime(hCamera, uDelayTimeUs):
+	err_code = _sdk.CameraSetTriggerDelayTime(hCamera, uDelayTimeUs)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetTriggerDelayTime(hCamera):
+	puDelayTimeUs = c_uint()
+	err_code = _sdk.CameraGetTriggerDelayTime(hCamera, byref(puDelayTimeUs))
+	SetLastError(err_code)
+	return puDelayTimeUs.value
+
+def CameraSetTriggerCount(hCamera, iCount):
+	err_code = _sdk.CameraSetTriggerCount(hCamera, iCount)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetTriggerCount(hCamera):
+	piCount = c_int()
+	err_code = _sdk.CameraGetTriggerCount(hCamera, byref(piCount))
+	SetLastError(err_code)
+	return piCount.value
+
+def CameraSoftTrigger(hCamera):
+	err_code = _sdk.CameraSoftTrigger(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetTriggerMode(hCamera, iModeSel):
+	err_code = _sdk.CameraSetTriggerMode(hCamera, iModeSel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetTriggerMode(hCamera):
+	piModeSel = c_int()
+	err_code = _sdk.CameraGetTriggerMode(hCamera, byref(piModeSel))
+	SetLastError(err_code)
+	return piModeSel.value
+
+def CameraSetStrobeMode(hCamera, iMode):
+	err_code = _sdk.CameraSetStrobeMode(hCamera, iMode)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetStrobeMode(hCamera):
+	piMode = c_int()
+	err_code = _sdk.CameraGetStrobeMode(hCamera, byref(piMode))
+	SetLastError(err_code)
+	return piMode.value
+
+def CameraSetStrobeDelayTime(hCamera, uDelayTimeUs):
+	err_code = _sdk.CameraSetStrobeDelayTime(hCamera, uDelayTimeUs)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetStrobeDelayTime(hCamera):
+	upDelayTimeUs = c_uint()
+	err_code = _sdk.CameraGetStrobeDelayTime(hCamera, byref(upDelayTimeUs))
+	SetLastError(err_code)
+	return upDelayTimeUs.value
+
+def CameraSetStrobePulseWidth(hCamera, uTimeUs):
+	err_code = _sdk.CameraSetStrobePulseWidth(hCamera, uTimeUs)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetStrobePulseWidth(hCamera):
+	upTimeUs = c_uint()
+	err_code = _sdk.CameraGetStrobePulseWidth(hCamera, byref(upTimeUs))
+	SetLastError(err_code)
+	return upTimeUs.value
+
+def CameraSetStrobePolarity(hCamera, uPolarity):
+	err_code = _sdk.CameraSetStrobePolarity(hCamera, uPolarity)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetStrobePolarity(hCamera):
+	upPolarity = c_uint()
+	err_code = _sdk.CameraGetStrobePolarity(hCamera, byref(upPolarity))
+	SetLastError(err_code)
+	return upPolarity.value
+
+def CameraSetExtTrigSignalType(hCamera, iType):
+	err_code = _sdk.CameraSetExtTrigSignalType(hCamera, iType)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetExtTrigSignalType(hCamera):
+	ipType = c_int()
+	err_code = _sdk.CameraGetExtTrigSignalType(hCamera, byref(ipType))
+	SetLastError(err_code)
+	return ipType.value
+
+def CameraSetExtTrigShutterType(hCamera, iType):
+	err_code = _sdk.CameraSetExtTrigShutterType(hCamera, iType)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetExtTrigShutterType(hCamera):
+	ipType = c_int()
+	err_code = _sdk.CameraGetExtTrigShutterType(hCamera, byref(ipType))
+	SetLastError(err_code)
+	return ipType.value
+
+def CameraSetExtTrigDelayTime(hCamera, uDelayTimeUs):
+	err_code = _sdk.CameraSetExtTrigDelayTime(hCamera, uDelayTimeUs)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetExtTrigDelayTime(hCamera):
+	upDelayTimeUs = c_uint()
+	err_code = _sdk.CameraGetExtTrigDelayTime(hCamera, byref(upDelayTimeUs))
+	SetLastError(err_code)
+	return upDelayTimeUs.value
+
+def CameraSetExtTrigJitterTime(hCamera, uTimeUs):
+	err_code = _sdk.CameraSetExtTrigJitterTime(hCamera, uTimeUs)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetExtTrigJitterTime(hCamera):
+	upTimeUs = c_uint()
+	err_code = _sdk.CameraGetExtTrigJitterTime(hCamera, byref(upTimeUs))
+	SetLastError(err_code)
+	return upTimeUs.value
+
+def CameraGetExtTrigCapability(hCamera):
+	puCapabilityMask = c_uint()
+	err_code = _sdk.CameraGetExtTrigCapability(hCamera, byref(puCapabilityMask))
+	SetLastError(err_code)
+	return puCapabilityMask.value
+
+def CameraPauseLevelTrigger(hCamera):
+	err_code = _sdk.CameraPauseLevelTrigger(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetResolutionForSnap(hCamera):
+	pImageResolution = tSdkImageResolution()
+	err_code = _sdk.CameraGetResolutionForSnap(hCamera, byref(pImageResolution))
+	SetLastError(err_code)
+	return pImageResolution
+
+def CameraSetResolutionForSnap(hCamera, pImageResolution):
+	err_code = _sdk.CameraSetResolutionForSnap(hCamera, byref(pImageResolution))
+	SetLastError(err_code)
+	return err_code
+
+def CameraCustomizeResolution(hCamera):
+	pImageCustom = tSdkImageResolution()
+	err_code = _sdk.CameraCustomizeResolution(hCamera, byref(pImageCustom))
+	SetLastError(err_code)
+	return pImageCustom
+
+def CameraCustomizeReferWin(hCamera, iWinType, hParent):
+	piHOff = c_int()
+	piVOff = c_int()
+	piWidth = c_int()
+	piHeight = c_int()
+	err_code = _sdk.CameraCustomizeReferWin(hCamera, iWinType, hParent, byref(piHOff), byref(piVOff), byref(piWidth), byref(piHeight))
+	SetLastError(err_code)
+	return (piHOff.value, piVOff.value, piWidth.value, piHeight.value)
+
+def CameraShowSettingPage(hCamera, bShow):
+	err_code = _sdk.CameraShowSettingPage(hCamera, bShow)
+	SetLastError(err_code)
+	return err_code
+
+def CameraCreateSettingPage(hCamera, hParent, pWinText, pCallbackFunc = None, pCallbackCtx = 0, uReserved = 0):
+	err_code = _sdk.CameraCreateSettingPage(hCamera, hParent, _str_to_string_buffer(pWinText), pCallbackFunc, c_void_p(pCallbackCtx), uReserved)
+	SetLastError(err_code)
+	return err_code
+
+def CameraCreateSettingPageEx(hCamera):
+	err_code = _sdk.CameraCreateSettingPageEx(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetActiveSettingSubPage(hCamera, index):
+	err_code = _sdk.CameraSetActiveSettingSubPage(hCamera, index)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetSettingPageParent(hCamera, hParentWnd, Flags):
+	err_code = _sdk.CameraSetSettingPageParent(hCamera, hParentWnd, Flags)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetSettingPageHWnd(hCamera):
+	hWnd = c_void_p()
+	err_code = _sdk.CameraGetSettingPageHWnd(hCamera, byref(hWnd))
+	SetLastError(err_code)
+	return hWnd.value
+
+def CameraSpecialControl(hCamera, dwCtrlCode, dwParam, lpData):
+	err_code = _sdk.CameraSpecialControl(hCamera, dwCtrlCode, dwParam, c_void_p(lpData) )
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetFrameStatistic(hCamera):
+	psFrameStatistic = tSdkFrameStatistic()
+	err_code = _sdk.CameraGetFrameStatistic(hCamera, byref(psFrameStatistic))
+	SetLastError(err_code)
+	return psFrameStatistic
+
+def CameraSetNoiseFilter(hCamera, bEnable):
+	err_code = _sdk.CameraSetNoiseFilter(hCamera, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetNoiseFilterState(hCamera):
+	pEnable = c_int()
+	err_code = _sdk.CameraGetNoiseFilterState(hCamera, byref(pEnable))
+	SetLastError(err_code)
+	return pEnable.value
+
+def CameraRstTimeStamp(hCamera):
+	err_code = _sdk.CameraRstTimeStamp(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSaveUserData(hCamera, uStartAddr, pbData):
+	err_code = _sdk.CameraSaveUserData(hCamera, uStartAddr, pbData, len(pbData))
+	SetLastError(err_code)
+	return err_code
+
+def CameraLoadUserData(hCamera, uStartAddr, ilen):
+	pbData = create_string_buffer(ilen)
+	err_code = _sdk.CameraLoadUserData(hCamera, uStartAddr, pbData, ilen)
+	SetLastError(err_code)
+	return pbData[:]
+
+def CameraGetFriendlyName(hCamera):
+	pName = create_string_buffer(64)
+	err_code = _sdk.CameraGetFriendlyName(hCamera, pName)
+	SetLastError(err_code)
+	return _string_buffer_to_str(pName)
+
+def CameraSetFriendlyName(hCamera, pName):
+	pNameBuf = _str_to_string_buffer(pName)
+	resize(pNameBuf, 64)
+	err_code = _sdk.CameraSetFriendlyName(hCamera, pNameBuf)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSdkGetVersionString():
+	pVersionString = create_string_buffer(64)
+	err_code = _sdk.CameraSdkGetVersionString(pVersionString)
+	SetLastError(err_code)
+	return _string_buffer_to_str(pVersionString)
+
+def CameraCheckFwUpdate(hCamera):
+	pNeedUpdate = c_int()
+	err_code = _sdk.CameraCheckFwUpdate(hCamera, byref(pNeedUpdate))
+	SetLastError(err_code)
+	return pNeedUpdate.value
+
+def CameraGetFirmwareVersion(hCamera):
+	pVersion = create_string_buffer(64)
+	err_code = _sdk.CameraGetFirmwareVersion(hCamera, pVersion)
+	SetLastError(err_code)
+	return _string_buffer_to_str(pVersion)
+
+def CameraGetEnumInfo(hCamera):
+	pCameraInfo = tSdkCameraDevInfo()
+	err_code = _sdk.CameraGetEnumInfo(hCamera, byref(pCameraInfo))
+	SetLastError(err_code)
+	return pCameraInfo
+
+def CameraGetInerfaceVersion(hCamera):
+	pVersion = create_string_buffer(64)
+	err_code = _sdk.CameraGetInerfaceVersion(hCamera, pVersion)
+	SetLastError(err_code)
+	return _string_buffer_to_str(pVersion)
+
+def CameraSetIOState(hCamera, iOutputIOIndex, uState):
+	err_code = _sdk.CameraSetIOState(hCamera, iOutputIOIndex, uState)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetIOState(hCamera, iInputIOIndex):
+	puState = c_int()
+	err_code = _sdk.CameraGetIOState(hCamera, iInputIOIndex, byref(puState))
+	SetLastError(err_code)
+	return puState.value
+
+def CameraSetInPutIOMode(hCamera, iInputIOIndex, iMode):
+	err_code = _sdk.CameraSetInPutIOMode(hCamera, iInputIOIndex, iMode)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetOutPutIOMode(hCamera, iOutputIOIndex, iMode):
+	err_code = _sdk.CameraSetOutPutIOMode(hCamera, iOutputIOIndex, iMode)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetOutPutPWM(hCamera, iOutputIOIndex, iCycle, uDuty):
+	err_code = _sdk.CameraSetOutPutPWM(hCamera, iOutputIOIndex, iCycle, uDuty)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetAeAlgorithm(hCamera, iIspProcessor, iAeAlgorithmSel):
+	err_code = _sdk.CameraSetAeAlgorithm(hCamera, iIspProcessor, iAeAlgorithmSel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAeAlgorithm(hCamera, iIspProcessor):
+	piAlgorithmSel = c_int()
+	err_code = _sdk.CameraGetAeAlgorithm(hCamera, iIspProcessor, byref(piAlgorithmSel))
+	SetLastError(err_code)
+	return piAlgorithmSel.value
+
+def CameraSetBayerDecAlgorithm(hCamera, iIspProcessor, iAlgorithmSel):
+	err_code = _sdk.CameraSetBayerDecAlgorithm(hCamera, iIspProcessor, iAlgorithmSel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetBayerDecAlgorithm(hCamera, iIspProcessor):
+	piAlgorithmSel = c_int()
+	err_code = _sdk.CameraGetBayerDecAlgorithm(hCamera, iIspProcessor, byref(piAlgorithmSel))
+	SetLastError(err_code)
+	return piAlgorithmSel.value
+
+def CameraSetIspProcessor(hCamera, iIspProcessor):
+	err_code = _sdk.CameraSetIspProcessor(hCamera, iIspProcessor)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetIspProcessor(hCamera):
+	piIspProcessor = c_int()
+	err_code = _sdk.CameraGetIspProcessor(hCamera, byref(piIspProcessor))
+	SetLastError(err_code)
+	return piIspProcessor.value
+
+def CameraSetBlackLevel(hCamera, iBlackLevel):
+	err_code = _sdk.CameraSetBlackLevel(hCamera, iBlackLevel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetBlackLevel(hCamera):
+	piBlackLevel = c_int()
+	err_code = _sdk.CameraGetBlackLevel(hCamera, byref(piBlackLevel))
+	SetLastError(err_code)
+	return piBlackLevel.value
+
+def CameraSetWhiteLevel(hCamera, iWhiteLevel):
+	err_code = _sdk.CameraSetWhiteLevel(hCamera, iWhiteLevel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetWhiteLevel(hCamera):
+	piWhiteLevel = c_int()
+	err_code = _sdk.CameraGetWhiteLevel(hCamera, byref(piWhiteLevel))
+	SetLastError(err_code)
+	return piWhiteLevel.value
+
+def CameraSetIspOutFormat(hCamera, uFormat):
+	err_code = _sdk.CameraSetIspOutFormat(hCamera, uFormat)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetIspOutFormat(hCamera):
+	puFormat = c_int()
+	err_code = _sdk.CameraGetIspOutFormat(hCamera, byref(puFormat))
+	SetLastError(err_code)
+	return puFormat.value
+
+def CameraGetErrorString(iStatusCode):
+	_sdk.CameraGetErrorString.restype = c_char_p
+	msg = _sdk.CameraGetErrorString(iStatusCode)
+	if msg:
+		return _string_buffer_to_str(msg)
+	else:
+		return ''
+
+def CameraGetImageBufferEx2(hCamera, pImageData, uOutFormat, wTimes):
+	piWidth = c_int()
+	piHeight = c_int()
+	err_code = _sdk.CameraGetImageBufferEx2(hCamera, c_void_p(pImageData), uOutFormat, byref(piWidth), byref(piHeight), wTimes)
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return (piWidth.value, piHeight.value)
+
+def CameraGetImageBufferEx3(hCamera, pImageData, uOutFormat, wTimes):
+	piWidth = c_int()
+	piHeight = c_int()
+	puTimeStamp = c_int()
+	err_code = _sdk.CameraGetImageBufferEx3(hCamera, c_void_p(pImageData), uOutFormat, byref(piWidth), byref(piHeight), byref(puTimeStamp), wTimes)
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return (piWidth.value, piHeight.value, puTimeStamp.value)
+
+def CameraGetCapabilityEx2(hCamera):
+	pMaxWidth = c_int()
+	pMaxHeight = c_int()
+	pbColorCamera = c_int()
+	err_code = _sdk.CameraGetCapabilityEx2(hCamera, byref(pMaxWidth), byref(pMaxHeight), byref(pbColorCamera))
+	SetLastError(err_code)
+	return (pMaxWidth.value, pMaxHeight.value, pbColorCamera.value)
+
+def CameraReConnect(hCamera):
+	err_code = _sdk.CameraReConnect(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraConnectTest(hCamera):
+	err_code = _sdk.CameraConnectTest(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetLedEnable(hCamera, index, enable):
+	err_code = _sdk.CameraSetLedEnable(hCamera, index, enable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetLedEnable(hCamera, index):
+	enable = c_int()
+	err_code = _sdk.CameraGetLedEnable(hCamera, index, byref(enable))
+	SetLastError(err_code)
+	return enable.value
+
+def CameraSetLedOnOff(hCamera, index, onoff):
+	err_code = _sdk.CameraSetLedOnOff(hCamera, index, onoff)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetLedOnOff(hCamera, index):
+	onoff = c_int()
+	err_code = _sdk.CameraGetLedOnOff(hCamera, index, byref(onoff))
+	SetLastError(err_code)
+	return onoff.value
+
+def CameraSetLedDuration(hCamera, index, duration):
+	err_code = _sdk.CameraSetLedDuration(hCamera, index, duration)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetLedDuration(hCamera, index):
+	duration = c_uint()
+	err_code = _sdk.CameraGetLedDuration(hCamera, index, byref(duration))
+	SetLastError(err_code)
+	return duration.value
+
+def CameraSetLedBrightness(hCamera, index, uBrightness):
+	err_code = _sdk.CameraSetLedBrightness(hCamera, index, uBrightness)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetLedBrightness(hCamera, index):
+	uBrightness = c_uint()
+	err_code = _sdk.CameraGetLedBrightness(hCamera, index, byref(uBrightness))
+	SetLastError(err_code)
+	return uBrightness.value
+
+def CameraEnableTransferRoi(hCamera, uEnableMask):
+	err_code = _sdk.CameraEnableTransferRoi(hCamera, uEnableMask)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetTransferRoi(hCamera, index, X1, Y1, X2, Y2):
+	err_code = _sdk.CameraSetTransferRoi(hCamera, index, X1, Y1, X2, Y2)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetTransferRoi(hCamera, index):
+	pX1 = c_uint()
+	pY1 = c_uint()
+	pX2 = c_uint()
+	pY2 = c_uint()
+	err_code = _sdk.CameraGetTransferRoi(hCamera, index, byref(pX1), byref(pY1), byref(pX2), byref(pY2))
+	SetLastError(err_code)
+	return (pX1.value, pY1.value, pX2.value, pY2.value)
+
+def CameraAlignMalloc(size, align = 16):
+	_sdk.CameraAlignMalloc.restype = c_void_p
+	r = _sdk.CameraAlignMalloc(size, align)
+	return r
+
+def CameraAlignFree(membuffer):
+	_sdk.CameraAlignFree(c_void_p(membuffer))
+
+def CameraSetAutoConnect(hCamera, bEnable):
+	err_code = _sdk.CameraSetAutoConnect(hCamera, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetAutoConnect(hCamera):
+	pbEnable = c_int()
+	err_code = _sdk.CameraGetAutoConnect(hCamera, byref(pbEnable))
+	SetLastError(err_code)
+	return pbEnable.value
+
+def CameraGetReConnectCounts(hCamera):
+	puCounts = c_int()
+	err_code = _sdk.CameraGetReConnectCounts(hCamera, byref(puCounts))
+	SetLastError(err_code)
+	return puCounts.value
+
+def CameraSetSingleGrabMode(hCamera, bEnable):
+	err_code = _sdk.CameraSetSingleGrabMode(hCamera, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetSingleGrabMode(hCamera):
+	pbEnable = c_int()
+	err_code = _sdk.CameraGetSingleGrabMode(hCamera, byref(pbEnable))
+	SetLastError(err_code)
+	return pbEnable.value
+
+def CameraRestartGrab(hCamera):
+	err_code = _sdk.CameraRestartGrab(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraEvaluateImageDefinition(hCamera, iAlgorithSel, pbyIn, pFrInfo):
+	DefinitionValue = c_double()
+	err_code = _sdk.CameraEvaluateImageDefinition(hCamera, iAlgorithSel, c_void_p(pbyIn), byref(pFrInfo), byref(DefinitionValue))
+	SetLastError(err_code)
+	return DefinitionValue.value
+
+def CameraDrawText(pRgbBuffer, pFrInfo, pFontFileName, FontWidth, FontHeight, pText, Left, Top, Width, Height, TextColor, uFlags):
+	err_code = _sdk.CameraDrawText(c_void_p(pRgbBuffer), byref(pFrInfo), _str_to_string_buffer(pFontFileName), FontWidth, FontHeight, _str_to_string_buffer(pText), Left, Top, Width, Height, TextColor, uFlags)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGigeGetIp(pCameraInfo):
+	CamIp = create_string_buffer(32)
+	CamMask = create_string_buffer(32)
+	CamGateWay = create_string_buffer(32)
+	EtIp = create_string_buffer(32)
+	EtMask = create_string_buffer(32)
+	EtGateWay = create_string_buffer(32)
+	err_code = _sdk.CameraGigeGetIp(byref(pCameraInfo), CamIp, CamMask, CamGateWay, EtIp, EtMask, EtGateWay)
+	SetLastError(err_code)
+	return (_string_buffer_to_str(CamIp), _string_buffer_to_str(CamMask), _string_buffer_to_str(CamGateWay), 
+		_string_buffer_to_str(EtIp), _string_buffer_to_str(EtMask), _string_buffer_to_str(EtGateWay) )
+
+def CameraGigeSetIp(pCameraInfo, Ip, SubMask, GateWay, bPersistent):
+	err_code = _sdk.CameraGigeSetIp(byref(pCameraInfo), 
+		_str_to_string_buffer(Ip), _str_to_string_buffer(SubMask), _str_to_string_buffer(GateWay), bPersistent)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGigeGetMac(pCameraInfo):
+	CamMac = create_string_buffer(32)
+	EtMac = create_string_buffer(32)
+	err_code = _sdk.CameraGigeGetMac(byref(pCameraInfo), CamMac, EtMac)
+	SetLastError(err_code)
+	return (_string_buffer_to_str(CamMac), _string_buffer_to_str(EtMac) )
+
+def CameraEnableFastResponse(hCamera):
+	err_code = _sdk.CameraEnableFastResponse(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetCorrectDeadPixel(hCamera, bEnable):
+	err_code = _sdk.CameraSetCorrectDeadPixel(hCamera, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetCorrectDeadPixel(hCamera):
+	pbEnable = c_int()
+	err_code = _sdk.CameraGetCorrectDeadPixel(hCamera, byref(pbEnable))
+	SetLastError(err_code)
+	return pbEnable.value
+
+def CameraFlatFieldingCorrectSetEnable(hCamera, bEnable):
+	err_code = _sdk.CameraFlatFieldingCorrectSetEnable(hCamera, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraFlatFieldingCorrectGetEnable(hCamera):
+	pbEnable = c_int()
+	err_code = _sdk.CameraFlatFieldingCorrectGetEnable(hCamera, byref(pbEnable))
+	SetLastError(err_code)
+	return pbEnable.value
+
+def CameraFlatFieldingCorrectSetParameter(hCamera, pDarkFieldingImage, pDarkFieldingFrInfo, pLightFieldingImage, pLightFieldingFrInfo):
+	err_code = _sdk.CameraFlatFieldingCorrectSetParameter(hCamera, c_void_p(pDarkFieldingImage), byref(pDarkFieldingFrInfo), c_void_p(pLightFieldingImage), byref(pLightFieldingFrInfo))
+	SetLastError(err_code)
+	return err_code
+
+def CameraFlatFieldingCorrectGetParameterState(hCamera):
+	pbValid = c_int()
+	pFilePath = create_string_buffer(1024)
+	err_code = _sdk.CameraFlatFieldingCorrectGetParameterState(hCamera, byref(pbValid), pFilePath)
+	SetLastError(err_code)
+	return (pbValid.value, _string_buffer_to_str(pFilePath) )
+
+def CameraFlatFieldingCorrectSaveParameterToFile(hCamera, pszFileName):
+	err_code = _sdk.CameraFlatFieldingCorrectSaveParameterToFile(hCamera, _str_to_string_buffer(pszFileName))
+	SetLastError(err_code)
+	return err_code
+
+def CameraFlatFieldingCorrectLoadParameterFromFile(hCamera, pszFileName):
+	err_code = _sdk.CameraFlatFieldingCorrectLoadParameterFromFile(hCamera, _str_to_string_buffer(pszFileName))
+	SetLastError(err_code)
+	return err_code
+
+def CameraCommonCall(hCamera, pszCall, uResultBufSize):
+	pszResult = create_string_buffer(uResultBufSize) if uResultBufSize > 0 else None
+	err_code = _sdk.CameraCommonCall(hCamera, _str_to_string_buffer(pszCall), pszResult, uResultBufSize)
+	SetLastError(err_code)
+	return _string_buffer_to_str(pszResult) if pszResult else ''
+
+def CameraSetDenoise3DParams(hCamera, bEnable, nCount, Weights):
+	assert(nCount >= 2 and nCount <= 8)
+	if Weights:
+		assert(len(Weights) == nCount)
+		WeightsNative = (c_float * nCount)(*Weights)
+	else:
+		WeightsNative = None
+	err_code = _sdk.CameraSetDenoise3DParams(hCamera, bEnable, nCount, WeightsNative)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetDenoise3DParams(hCamera):
+	bEnable = c_int()
+	nCount = c_int()
+	bUseWeight = c_int()
+	Weights = (c_float * 8)()
+	err_code = _sdk.CameraGetDenoise3DParams(hCamera, byref(bEnable), byref(nCount), byref(bUseWeight), Weights)
+	SetLastError(err_code)
+	bEnable, nCount, bUseWeight = bEnable.value, nCount.value, bUseWeight.value
+	if bUseWeight:
+		Weights = Weights[:nCount]
+	else:
+		Weights = None
+	return (bEnable, nCount, bUseWeight, Weights)
+
+def CameraManualDenoise3D(InFramesHead, InFramesData, nCount, Weights, OutFrameHead, OutFrameData):
+	assert(nCount > 0)
+	assert(len(InFramesData) == nCount)
+	assert(Weights is None or len(Weights) == nCount)
+	InFramesDataNative = (c_void_p * nCount)(*InFramesData)
+	WeightsNative = (c_float * nCount)(*Weights) if Weights else None
+	err_code = _sdk.CameraManualDenoise3D(byref(InFramesHead), InFramesDataNative, nCount, WeightsNative, byref(OutFrameHead), c_void_p(OutFrameData))
+	SetLastError(err_code)
+	return err_code
+
+def CameraCustomizeDeadPixels(hCamera, hParent):
+	err_code = _sdk.CameraCustomizeDeadPixels(hCamera, hParent)
+	SetLastError(err_code)
+	return err_code
+
+def CameraReadDeadPixels(hCamera):
+	pNumPixel = c_int()
+	err_code = _sdk.CameraReadDeadPixels(hCamera, None, None, byref(pNumPixel))
+	SetLastError(err_code)
+	if pNumPixel.value < 1:
+		return None
+	UShortArray = c_ushort * pNumPixel.value
+	pRows = UShortArray()
+	pCols = UShortArray()
+	err_code = _sdk.CameraReadDeadPixels(hCamera, pRows, pCols, byref(pNumPixel))
+	SetLastError(err_code)
+	if err_code == 0:
+		pNumPixel = pNumPixel.value
+	else:
+		pNumPixel = 0
+	return (pRows[:pNumPixel], pCols[:pNumPixel])
+
+def CameraAddDeadPixels(hCamera, pRows, pCols, NumPixel):
+	UShortArray = c_ushort * NumPixel
+	pRowsNative = UShortArray(*pRows)
+	pColsNative = UShortArray(*pCols)
+	err_code = _sdk.CameraAddDeadPixels(hCamera, pRowsNative, pColsNative, NumPixel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraRemoveDeadPixels(hCamera, pRows, pCols, NumPixel):
+	UShortArray = c_ushort * NumPixel
+	pRowsNative = UShortArray(*pRows)
+	pColsNative = UShortArray(*pCols)
+	err_code = _sdk.CameraRemoveDeadPixels(hCamera, pRowsNative, pColsNative, NumPixel)
+	SetLastError(err_code)
+	return err_code
+
+def CameraRemoveAllDeadPixels(hCamera):
+	err_code = _sdk.CameraRemoveAllDeadPixels(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSaveDeadPixels(hCamera):
+	err_code = _sdk.CameraSaveDeadPixels(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSaveDeadPixelsToFile(hCamera, sFileName):
+	err_code = _sdk.CameraSaveDeadPixelsToFile(hCamera, _str_to_string_buffer(sFileName))
+	SetLastError(err_code)
+	return err_code
+
+def CameraLoadDeadPixelsFromFile(hCamera, sFileName):
+	err_code = _sdk.CameraLoadDeadPixelsFromFile(hCamera, _str_to_string_buffer(sFileName))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetImageBufferPriority(hCamera, wTimes, Priority):
+	pFrameInfo = tSdkFrameHead()
+	pbyBuffer = c_void_p()
+	err_code = _sdk.CameraGetImageBufferPriority(hCamera, byref(pFrameInfo), byref(pbyBuffer), wTimes, Priority)
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return (pbyBuffer.value, pFrameInfo)
+
+def CameraGetImageBufferPriorityEx(hCamera, wTimes, Priority):
+	_sdk.CameraGetImageBufferPriorityEx.restype = c_void_p
+	piWidth = c_int()
+	piHeight = c_int()
+	pFrameBuffer = _sdk.CameraGetImageBufferPriorityEx(hCamera, byref(piWidth), byref(piHeight), wTimes, Priority)
+	err_code = CAMERA_STATUS_SUCCESS if pFrameBuffer else CAMERA_STATUS_TIME_OUT
+	SetLastError(err_code)
+	if pFrameBuffer:
+		return (pFrameBuffer, piWidth.value, piHeight.value)
+	else:
+		raise CameraException(err_code)
+
+def CameraGetImageBufferPriorityEx2(hCamera, pImageData, uOutFormat, wTimes, Priority):
+	piWidth = c_int()
+	piHeight = c_int()
+	err_code = _sdk.CameraGetImageBufferPriorityEx2(hCamera, c_void_p(pImageData), uOutFormat, byref(piWidth), byref(piHeight), wTimes, Priority)
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return (piWidth.value, piHeight.value)
+
+def CameraGetImageBufferPriorityEx3(hCamera, pImageData, uOutFormat, wTimes, Priority):
+	piWidth = c_int()
+	piHeight = c_int()
+	puTimeStamp = c_uint()
+	err_code = _sdk.CameraGetImageBufferPriorityEx3(hCamera, c_void_p(pImageData), uOutFormat, byref(piWidth), byref(piHeight), byref(puTimeStamp), wTimes, Priority)
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return (piWidth.value, piHeight.value, puTimeStamp.value)
+
+def CameraClearBuffer(hCamera):
+	err_code = _sdk.CameraClearBuffer(hCamera)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSoftTriggerEx(hCamera, uFlags):
+	err_code = _sdk.CameraSoftTriggerEx(hCamera, uFlags)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetHDR(hCamera, value):
+	err_code = _sdk.CameraSetHDR(hCamera, value)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetHDR(hCamera):
+	value = c_int()
+	err_code = _sdk.CameraGetHDR(hCamera, byref(value))
+	SetLastError(err_code)
+	return value.value
+
+def CameraGetFrameID(hCamera):
+	FrameID = c_uint()
+	err_code = _sdk.CameraGetFrameID(hCamera, byref(FrameID))
+	SetLastError(err_code)
+	return FrameID.value
+
+def CameraGetFrameTimeStamp(hCamera):
+	TimeStamp = c_uint64()
+	TimeStampL = c_uint32.from_buffer(TimeStamp)
+	TimeStampH = c_uint32.from_buffer(TimeStamp, 4)
+	err_code = _sdk.CameraGetFrameTimeStamp(hCamera, byref(TimeStampL), byref(TimeStampH))
+	SetLastError(err_code)
+	return TimeStamp.value
+
+def CameraSetHDRGainMode(hCamera, value):
+	err_code = _sdk.CameraSetHDRGainMode(hCamera, value)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetHDRGainMode(hCamera):
+	value = c_int()
+	err_code = _sdk.CameraGetHDRGainMode(hCamera, byref(value))
+	SetLastError(err_code)
+	return value.value
+
+def CameraCreateDIBitmap(hDC, pFrameBuffer, pFrameHead):
+	outBitmap = c_void_p()
+	err_code = _sdk.CameraCreateDIBitmap(hDC, c_void_p(pFrameBuffer), byref(pFrameHead), byref(outBitmap))
+	SetLastError(err_code)
+	return outBitmap.value
+
+def CameraDrawFrameBuffer(pFrameBuffer, pFrameHead, hWnd, Algorithm, Mode):
+	err_code = _sdk.CameraDrawFrameBuffer(c_void_p(pFrameBuffer), byref(pFrameHead), c_void_p(hWnd), Algorithm, Mode)
+	SetLastError(err_code)
+	return err_code
+
+def CameraFlipFrameBuffer(pFrameBuffer, pFrameHead, Flags):
+	err_code = _sdk.CameraFlipFrameBuffer(c_void_p(pFrameBuffer), byref(pFrameHead), Flags)
+	SetLastError(err_code)
+	return err_code
+
+def CameraConvertFrameBufferFormat(hCamera, pInFrameBuffer, pOutFrameBuffer, outWidth, outHeight, outMediaType, pFrameHead):
+	err_code = _sdk.CameraConvertFrameBufferFormat(hCamera, c_void_p(pInFrameBuffer), c_void_p(pOutFrameBuffer), outWidth, outHeight, outMediaType, byref(pFrameHead))
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetConnectionStatusCallback(hCamera, pCallBack, pContext = 0):
+	err_code = _sdk.CameraSetConnectionStatusCallback(hCamera, pCallBack, c_void_p(pContext) )
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetLightingControllerMode(hCamera, index, mode):
+	err_code = _sdk.CameraSetLightingControllerMode(hCamera, index, mode)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetLightingControllerState(hCamera, index, state):
+	err_code = _sdk.CameraSetLightingControllerState(hCamera, index, state)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetFrameResendCount(hCamera, count):
+	err_code = _sdk.CameraSetFrameResendCount(hCamera, count)
+	SetLastError(err_code)
+	return err_code
+
+def CameraSetUndistortParams(hCamera, width, height, cameraMatrix, distCoeffs):
+	assert(len(cameraMatrix) == 4)
+	assert(len(distCoeffs) == 5)
+	cameraMatrixNative = (c_double * len(cameraMatrix))(*cameraMatrix)
+	distCoeffsNative = (c_double * len(distCoeffs))(*distCoeffs)
+	err_code = _sdk.CameraSetUndistortParams(hCamera, width, height, cameraMatrixNative, distCoeffsNative)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetUndistortParams(hCamera):
+	width = c_int()
+	height = c_int()
+	cameraMatrix = (c_double * 4)()
+	distCoeffs = (c_double * 5)()
+	err_code = _sdk.CameraGetUndistortParams(hCamera, byref(width), byref(height), cameraMatrix, distCoeffs)
+	SetLastError(err_code)
+	width, height = width.value, height.value
+	cameraMatrix = cameraMatrix[:]
+	distCoeffs = distCoeffs[:]
+	return (width, height, cameraMatrix, distCoeffs)
+
+def CameraSetUndistortEnable(hCamera, bEnable):
+	err_code = _sdk.CameraSetUndistortEnable(hCamera, bEnable)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetUndistortEnable(hCamera):
+	value = c_int()
+	err_code = _sdk.CameraGetUndistortEnable(hCamera, byref(value))
+	SetLastError(err_code)
+	return value.value
+
+def CameraCustomizeUndistort(hCamera, hParent):
+	err_code = _sdk.CameraCustomizeUndistort(hCamera, hParent)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGetEyeCount(hCamera):
+	EyeCount = c_int()
+	err_code = _sdk.CameraGetEyeCount(hCamera, byref(EyeCount))
+	SetLastError(err_code)
+	return EyeCount.value
+
+def CameraMultiEyeImageProcess(hCamera, iEyeIndex, pbyIn, pInFrInfo, pbyOut, pOutFrInfo, uOutFormat, uReserved):
+	err_code = _sdk.CameraMultiEyeImageProcess(hCamera, iEyeIndex, c_void_p(pbyIn), byref(pInFrInfo), c_void_p(pbyOut), byref(pOutFrInfo), uOutFormat, uReserved)
+	SetLastError(err_code)
+	return err_code
+
+# CameraGrabber
+
+def CameraGrabber_CreateFromDevicePage():
+	Grabber = c_void_p()
+	err_code = _sdk.CameraGrabber_CreateFromDevicePage(byref(Grabber))
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return Grabber.value
+
+def CameraGrabber_CreateByIndex(Index):
+	Grabber = c_void_p()
+	err_code = _sdk.CameraGrabber_CreateByIndex(byref(Grabber), Index)
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return Grabber.value
+
+def CameraGrabber_CreateByName(Name):
+	Grabber = c_void_p()
+	err_code = _sdk.CameraGrabber_CreateByName(byref(Grabber), _str_to_string_buffer(Name))
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return Grabber.value
+
+def CameraGrabber_Create(pDevInfo):
+	Grabber = c_void_p()
+	err_code = _sdk.CameraGrabber_Create(byref(Grabber), byref(pDevInfo))
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return Grabber.value
+
+def CameraGrabber_Destroy(Grabber):
+	err_code = _sdk.CameraGrabber_Destroy(c_void_p(Grabber))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_SetHWnd(Grabber, hWnd):
+	err_code = _sdk.CameraGrabber_SetHWnd(c_void_p(Grabber), c_void_p(hWnd) )
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_SetPriority(Grabber, Priority):
+	err_code = _sdk.CameraGrabber_SetPriority(c_void_p(Grabber), Priority)
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_StartLive(Grabber):
+	err_code = _sdk.CameraGrabber_StartLive(c_void_p(Grabber))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_StopLive(Grabber):
+	err_code = _sdk.CameraGrabber_StopLive(c_void_p(Grabber))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_SaveImage(Grabber, TimeOut):
+	Image = c_void_p()
+	err_code = _sdk.CameraGrabber_SaveImage(c_void_p(Grabber), byref(Image), TimeOut)
+	SetLastError(err_code)
+	if err_code != 0:
+		raise CameraException(err_code)
+	return Image.value
+
+def CameraGrabber_SaveImageAsync(Grabber):
+	err_code = _sdk.CameraGrabber_SaveImageAsync(c_void_p(Grabber))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_SaveImageAsyncEx(Grabber, UserData):
+	err_code = _sdk.CameraGrabber_SaveImageAsyncEx(c_void_p(Grabber), c_void_p(UserData))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_SetSaveImageCompleteCallback(Grabber, Callback, Context = 0):
+	err_code = _sdk.CameraGrabber_SetSaveImageCompleteCallback(c_void_p(Grabber), Callback, c_void_p(Context))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_SetFrameListener(Grabber, Listener, Context = 0):
+	err_code = _sdk.CameraGrabber_SetFrameListener(c_void_p(Grabber), Listener, c_void_p(Context))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_SetRawCallback(Grabber, Callback, Context = 0):
+	err_code = _sdk.CameraGrabber_SetRawCallback(c_void_p(Grabber), Callback, c_void_p(Context))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_SetRGBCallback(Grabber, Callback, Context = 0):
+	err_code = _sdk.CameraGrabber_SetRGBCallback(c_void_p(Grabber), Callback, c_void_p(Context))
+	SetLastError(err_code)
+	return err_code
+
+def CameraGrabber_GetCameraHandle(Grabber):
+	hCamera = c_int()
+	err_code = _sdk.CameraGrabber_GetCameraHandle(c_void_p(Grabber), byref(hCamera))
+	SetLastError(err_code)
+	return hCamera.value
+
+def CameraGrabber_GetStat(Grabber):
+	stat = tSdkGrabberStat()
+	err_code = _sdk.CameraGrabber_GetStat(c_void_p(Grabber), byref(stat))
+	SetLastError(err_code)
+	return stat
+
+def CameraGrabber_GetCameraDevInfo(Grabber):
+	DevInfo = tSdkCameraDevInfo()
+	err_code = _sdk.CameraGrabber_GetCameraDevInfo(c_void_p(Grabber), byref(DevInfo))
+	SetLastError(err_code)
+	return DevInfo
+
+# CameraImage
+
+def CameraImage_Create(pFrameBuffer, pFrameHead, bCopy):
+	Image = c_void_p()
+	err_code = _sdk.CameraImage_Create(byref(Image), c_void_p(pFrameBuffer), byref(pFrameHead), bCopy)
+	SetLastError(err_code)
+	return Image.value
+
+def CameraImage_CreateEmpty():
+	Image = c_void_p()
+	err_code = _sdk.CameraImage_CreateEmpty(byref(Image))
+	SetLastError(err_code)
+	return Image.value
+
+def CameraImage_Destroy(Image):
+	err_code = _sdk.CameraImage_Destroy(c_void_p(Image))
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_GetData(Image):
+	DataBuffer = c_void_p()
+	HeadPtr = c_void_p()
+	err_code = _sdk.CameraImage_GetData(c_void_p(Image), byref(DataBuffer), byref(HeadPtr))
+	SetLastError(err_code)
+	if err_code == 0:
+		return (DataBuffer.value, tSdkFrameHead.from_address(HeadPtr.value) )
+	else:
+		return (0, None)
+
+def CameraImage_GetUserData(Image):
+	UserData = c_void_p()
+	err_code = _sdk.CameraImage_GetUserData(c_void_p(Image), byref(UserData))
+	SetLastError(err_code)
+	return UserData.value
+
+def CameraImage_SetUserData(Image, UserData):
+	err_code = _sdk.CameraImage_SetUserData(c_void_p(Image), c_void_p(UserData))
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_IsEmpty(Image):
+	IsEmpty = c_int()
+	err_code = _sdk.CameraImage_IsEmpty(c_void_p(Image), byref(IsEmpty))
+	SetLastError(err_code)
+	return IsEmpty.value
+
+def CameraImage_Draw(Image, hWnd, Algorithm):
+	err_code = _sdk.CameraImage_Draw(c_void_p(Image), c_void_p(hWnd), Algorithm)
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_DrawFit(Image, hWnd, Algorithm):
+	err_code = _sdk.CameraImage_DrawFit(c_void_p(Image), c_void_p(hWnd), Algorithm)
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_DrawToDC(Image, hDC, Algorithm, xDst, yDst, cxDst, cyDst):
+	err_code = _sdk.CameraImage_DrawToDC(c_void_p(Image), c_void_p(hDC), Algorithm, xDst, yDst, cxDst, cyDst)
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_DrawToDCFit(Image, hDC, Algorithm, xDst, yDst, cxDst, cyDst):
+	err_code = _sdk.CameraImage_DrawToDCFit(c_void_p(Image), c_void_p(hDC), Algorithm, xDst, yDst, cxDst, cyDst)
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_BitBlt(Image, hWnd, xDst, yDst, cxDst, cyDst, xSrc, ySrc):
+	err_code = _sdk.CameraImage_BitBlt(c_void_p(Image), c_void_p(hWnd), xDst, yDst, cxDst, cyDst, xSrc, ySrc)
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_BitBltToDC(Image, hDC, xDst, yDst, cxDst, cyDst, xSrc, ySrc):
+	err_code = _sdk.CameraImage_BitBltToDC(c_void_p(Image), c_void_p(hDC), xDst, yDst, cxDst, cyDst, xSrc, ySrc)
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_SaveAsBmp(Image, FileName):
+	err_code = _sdk.CameraImage_SaveAsBmp(c_void_p(Image), _str_to_string_buffer(FileName))
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_SaveAsJpeg(Image, FileName, Quality):
+	err_code = _sdk.CameraImage_SaveAsJpeg(c_void_p(Image), _str_to_string_buffer(FileName), Quality)
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_SaveAsPng(Image, FileName):
+	err_code = _sdk.CameraImage_SaveAsPng(c_void_p(Image), _str_to_string_buffer(FileName))
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_SaveAsRaw(Image, FileName, Format):
+	err_code = _sdk.CameraImage_SaveAsRaw(c_void_p(Image), _str_to_string_buffer(FileName), Format)
+	SetLastError(err_code)
+	return err_code
+
+def CameraImage_IPicture(Image):
+	NewPic = c_void_p()
+	err_code = _sdk.CameraImage_IPicture(c_void_p(Image), byref(NewPic))
+	SetLastError(err_code)
+	return NewPic.value

--- a/src/dice_game/launch/dice_game.launch.py
+++ b/src/dice_game/launch/dice_game.launch.py
@@ -1,0 +1,54 @@
+"""
+dice_game.launch.py
+
+Launches the three game nodes that run on the laptop:
+  - camera_server  : captures images and counts pips
+  - dj_control     : DJ (Robot 1, LEFT)  state machine
+  - bill_control   : BILL (Robot 2, RIGHT) state machine
+
+The FANUC driver nodes (action_servers + msg_publishers) for each robot
+are started separately in their own terminals, e.g.:
+
+  Terminal 1 (DJ drivers):
+    ros2 launch action_servers action_servers.launch.py \
+      robot_name:=DJ robot_ip:=10.8.4.16
+
+  Terminal 2 (DJ publishers):
+    ros2 launch msg_publishers message_publishers.launch.py \
+      robot_name:=DJ robot_ip:=10.8.4.16
+
+  Terminal 3 (BILL drivers):
+    ros2 launch action_servers action_servers.launch.py \
+      robot_name:=BILL robot_ip:=10.8.4.6
+
+  Terminal 4 (BILL publishers):
+    ros2 launch msg_publishers message_publishers.launch.py \
+      robot_name:=BILL robot_ip:=10.8.4.6
+
+  Terminal 5 (game):
+    ros2 launch dice_game dice_game.launch.py
+"""
+
+import launch
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    dj_node = Node(
+        package='dice_game',
+        executable='dj_control',
+        name='dj_control',
+        output='screen',
+    )
+
+    bill_node = Node(
+        package='dice_game',
+        executable='bill_control',
+        name='bill_control',
+        output='screen',
+    )
+
+    return launch.LaunchDescription([
+        dj_node,
+        bill_node,
+    ])

--- a/src/dice_game/package.xml
+++ b/src/dice_game/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>dice_game</name>
+  <version>0.0.1</version>
+  <description>Dice pip sequential counting game using two FANUC robots and two conveyors.</description>
+  <maintainer email="todo@todo.com">kate-bouse</maintainer>
+  <license>Apache-2.0</license>
+
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>fanuc_interfaces</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/src/dice_game/setup.cfg
+++ b/src/dice_game/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/dice_game
+[install]
+install_scripts=$base/lib/dice_game

--- a/src/dice_game/setup.py
+++ b/src/dice_game/setup.py
@@ -1,0 +1,31 @@
+from setuptools import find_packages, setup
+import os
+from glob import glob
+
+package_name = 'dice_game'
+
+setup(
+    name=package_name,
+    version='0.0.1',
+    packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+        (os.path.join('share', package_name, 'launch'), glob('launch/*.py')),
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    maintainer='kate-bouse',
+    maintainer_email='todo@todo.com',
+    description='Dice pip sequential counting game using two FANUC robots.',
+    license='Apache-2.0',
+    tests_require=['pytest'],
+    entry_points={
+        'console_scripts': [
+            'camera_server = dice_game.camera_server:main',
+            'dj_control    = dice_game.dj_control:main',
+            'bill_control  = dice_game.bill_control:main',
+        ],
+    },
+)

--- a/src/fanuc_interfaces/CMakeLists.txt
+++ b/src/fanuc_interfaces/CMakeLists.txt
@@ -42,11 +42,14 @@ set(msg_files
    "msg/IsMoving.msg"
    "msg/CurSpeed.msg"
    "msg/ProxReadings.msg"
+   "msg/DiceState.msg"
 )
 
 set(srv_files
    "srv/Mount.srv"
    "srv/SetSpeed.srv"
+   "srv/RequestHandoff.srv"
+   "srv/CapturePip.srv"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/src/fanuc_interfaces/action/JointPose.action
+++ b/src/fanuc_interfaces/action/JointPose.action
@@ -1,5 +1,5 @@
 #Goal
-# Set the robot to a series of joint angles Should be in the range of [-179.0, 179.0]
+# Set the robot to a series of joint angles Should be in the range of [-270.0, 270.0]
 
 # Joint angles
 float32 joint1
@@ -8,6 +8,8 @@ float32 joint3
 float32 joint4
 float32 joint5
 float32 joint6
+# Speed in mm/s [1, 300]. 0 = use current speed (no change).
+int32 speed
 ---
 #Result
 bool success

--- a/src/fanuc_interfaces/msg/DiceState.msg
+++ b/src/fanuc_interfaces/msg/DiceState.msg
@@ -1,0 +1,6 @@
+# Current game state published after every significant event
+
+int32 expected_pip      # Next pip we need to find (1-6)
+int32 dj_retries        # Total retries accumulated by DJ
+int32 bill_retries      # Total retries accumulated by BILL
+string robot_holding    # 'DJ', 'BILL', or 'IN_TRANSIT'

--- a/src/fanuc_interfaces/srv/CapturePip.srv
+++ b/src/fanuc_interfaces/srv/CapturePip.srv
@@ -1,0 +1,7 @@
+# Request a camera capture and pip count.
+# Returns -1 on failure.
+
+---
+int32 pip_count
+bool success
+string message

--- a/src/fanuc_interfaces/srv/RequestHandoff.srv
+++ b/src/fanuc_interfaces/srv/RequestHandoff.srv
@@ -1,0 +1,6 @@
+# Sender calls this on the receiver before running its conveyor.
+# Receiver moves to pickup position, then responds.
+
+string conveyor     # 'front' or 'back'
+---
+bool accepted

--- a/src/msg_publishers/dependencies/robot_controller.py
+++ b/src/msg_publishers/dependencies/robot_controller.py
@@ -20,6 +20,7 @@
 
 # Imports
 import math
+import time
 import typing
 from . import FANUCethernetipDriver
 
@@ -251,6 +252,7 @@ class robot:
         """! checks to see if robot is moving based on the value of the sync register 1=moving 0=not moving
         """
         pose1 = self.read_current_cartesian_pose()
+        time.sleep(0.1)
         pose2 = self.read_current_cartesian_pose()
         diff = list(map(lambda a, b: a - b, pose1, pose2))
         #print("Difference: ", diff)

--- a/tests/basic_routine_test.py
+++ b/tests/basic_routine_test.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+basic_routine_test.py  —  BILL routine test (non-interactive)
+
+Runs BILL through a pick-from-conveyor and set-on-conveyor sequence.
+Conveyor runs as a background monitor: starts when right sensor trips,
+stops when left sensor trips (reverse direction).
+
+Run:
+    python3 tests/basic_routine_test.py
+"""
+
+import time
+import threading
+
+import rclpy
+from rclpy.node import Node
+from rclpy.action import ActionClient
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
+
+from fanuc_interfaces.action import JointPose, OnRobotGripper, Conveyor
+from fanuc_interfaces.msg import ProxReadings, IsMoving
+
+# ── Joint positions ───────────────────────────────────────────────────────────
+BILL_HOME                   = [0.0,    0.0,    0.0,   0.0,   -90.0,  -45.0]
+BILL_PRESENT_TO_CAMERA      = [-65.17, 26.40,  -5.36, -78.83, 27.21,  31.95]
+BILL_SET_ON_CONVEYOR        = [-89.51, 22.82, -27.22,  1.25, -61.61, -48.54]
+BILL_PRE_SET_ON_CONVEYOR    = [-89.51, 18.89, -12.84,  1.14, -75.99, -48.22]  # NOTE: j5 was written as -61.61-75.99 — using -75.99
+BILL_PRE_PICK_FROM_CONVEYOR = [-109.77,  31.81,  -7.24,  0.633, -81.27, -27.79]
+BILL_PICK_FROM_CONVEYOR     = [-109.768, 34.16, -18.87,  0.668, -69.65, -27.93]
+
+# ── Gripper ───────────────────────────────────────────────────────────────────
+GRIPPER_OPEN_WIDTH  = 90   # mm
+GRIPPER_CLOSE_WIDTH = 50   # mm
+GRIPPER_FORCE       = 10   # N
+
+# ── Conveyor sensors (BILL front conveyor) ────────────────────────────────────
+CONVEYOR_START_SENSOR   = 'right'   # trip → start conveyor
+CONVEYOR_STOP_SENSOR    = 'left'    # trip → stop conveyor
+CONVEYOR_DIRECTION      = 'reverse'
+CONVEYOR_SENSOR_TIMEOUT = 200.0     # seconds per sensor
+
+# How long to wait for the robot to start moving after a command (seconds)
+MOTION_START_TIMEOUT    = 3.0
+# How long to wait for a motion to complete (seconds)
+MOTION_COMPLETE_TIMEOUT = 60.0
+
+
+class BillRoutineTest(Node):
+    def __init__(self):
+        super().__init__('bill_routine_test')
+        cb = ReentrantCallbackGroup()
+
+        self._joints  = ActionClient(self, JointPose,      'BILL/joint_pose',      callback_group=cb)
+        self._gripper = ActionClient(self, OnRobotGripper, 'BILL/onrobot_gripper', callback_group=cb)
+        self._convey  = ActionClient(self, Conveyor,       'BILL/conveyor',        callback_group=cb)
+
+        self._prox   = {'left': 0, 'right': 0}
+        self._moving = False
+
+        self.create_subscription(ProxReadings, 'BILL/prox_readings',
+            lambda msg: self._prox.update({'left': int(msg.left), 'right': int(msg.right)}), 10,
+            callback_group=cb)
+
+        self.create_subscription(IsMoving, 'BILL/is_moving',
+            lambda msg: setattr(self, '_moving', bool(msg.moving)), 10,
+            callback_group=cb)
+
+        # Conveyor monitor runs in background thread
+        self._conveyor_monitor_active = False
+        self._monitor_thread = threading.Thread(target=self._conveyor_monitor, daemon=True)
+        self._monitor_thread.start()
+
+    # ── Helpers ───────────────────────────────────────────────────────────────
+    def _wait(self, future, timeout=30.0):
+        deadline = time.time() + timeout
+        while not future.done():
+            if time.time() > deadline:
+                raise TimeoutError('Future timed out')
+            time.sleep(0.02)
+        return future.result()
+
+    def _wait_for_move(self):
+        """Block until BILL/is_moving goes True then False (motion starts and finishes)."""
+        # Wait for motion to start
+        deadline = time.time() + MOTION_START_TIMEOUT
+        while not self._moving:
+            if time.time() > deadline:
+                self.get_logger().warn('Robot did not register as moving — may have already arrived')
+                break
+            time.sleep(0.05)
+
+        # Wait for motion to finish
+        deadline = time.time() + MOTION_COMPLETE_TIMEOUT
+        while self._moving:
+            if time.time() > deadline:
+                raise TimeoutError('Motion did not complete within timeout')
+            time.sleep(0.05)
+
+    def _move(self, joints: list):
+        self.get_logger().info(f'Move → {joints}')
+        goal = JointPose.Goal()
+        goal.joint1, goal.joint2, goal.joint3 = joints[0], joints[1], joints[2]
+        goal.joint4, goal.joint5, goal.joint6 = joints[3], joints[4], joints[5]
+        self._joints.wait_for_server()
+        gh = self._wait(self._joints.send_goal_async(goal))
+        if not gh.accepted:
+            raise RuntimeError('Joint move rejected')
+        self._wait(gh.get_result_async(), timeout=MOTION_COMPLETE_TIMEOUT)
+
+    def _set_gripper(self, width: int):
+        goal = OnRobotGripper.Goal()
+        goal.width = width
+        goal.force = GRIPPER_FORCE
+        self._gripper.wait_for_server()
+        gh = self._wait(self._gripper.send_goal_async(goal))
+        if not gh.accepted:
+            raise RuntimeError('Gripper goal rejected')
+        self._wait(gh.get_result_async())
+        state = 'OPEN' if width >= GRIPPER_OPEN_WIDTH else 'CLOSE'
+        self.get_logger().info(f'Gripper {state}')
+        time.sleep(2.0)
+
+    def _conveyor_cmd(self, cmd: str):
+        goal = Conveyor.Goal()
+        goal.command = cmd
+        self._convey.wait_for_server()
+        gh = self._wait(self._convey.send_goal_async(goal))
+        if not gh.accepted:
+            raise RuntimeError('Conveyor goal rejected')
+        self._wait(gh.get_result_async())
+
+    # ── Conveyor background monitor ───────────────────────────────────────────
+    def _conveyor_monitor(self):
+        """
+        Runs one cycle in background:
+          Idle until activated → wait for start sensor (right) → start conveyor
+          → wait for stop sensor (left) → stop conveyor → signal done and exit.
+        """
+        # Wait until activated by run()
+        while not self._conveyor_monitor_active:
+            if not rclpy.ok():
+                return
+            time.sleep(0.05)
+
+        # Wait for start sensor
+        self.get_logger().info('Conveyor monitor: waiting for start sensor...')
+        deadline = time.time() + CONVEYOR_SENSOR_TIMEOUT
+        while not self._prox[CONVEYOR_START_SENSOR]:
+            if time.time() > deadline:
+                self.get_logger().warn('Conveyor monitor: start sensor timeout')
+                self._conveyor_monitor_active = False
+                return
+            time.sleep(0.05)
+
+        self.get_logger().info('Conveyor monitor: start sensor tripped → running')
+        self._conveyor_cmd(CONVEYOR_DIRECTION)
+
+        # Wait for stop sensor
+        deadline = time.time() + CONVEYOR_SENSOR_TIMEOUT
+        while not self._prox[CONVEYOR_STOP_SENSOR]:
+            if time.time() > deadline:
+                self.get_logger().warn('Conveyor monitor: stop sensor timeout')
+                break
+            time.sleep(0.05)
+
+        self._conveyor_cmd('stop')
+        self.get_logger().info('Conveyor monitor: stop sensor tripped → stopped')
+        self._conveyor_monitor_active = False   # signal run() to exit
+
+    # ── Main routine ──────────────────────────────────────────────────────────
+    def run(self):
+        self.get_logger().info('=== BILL routine test starting ===')
+
+        self._conveyor_monitor_active = True
+
+        self._move(BILL_HOME)
+        self._set_gripper(GRIPPER_OPEN_WIDTH)
+        self._move(BILL_PRE_PICK_FROM_CONVEYOR)
+        self._move(BILL_PICK_FROM_CONVEYOR)
+        self._set_gripper(GRIPPER_CLOSE_WIDTH)
+        self._move(BILL_PRE_PICK_FROM_CONVEYOR)
+        self._move(BILL_PRE_SET_ON_CONVEYOR)
+        self._move(BILL_SET_ON_CONVEYOR)
+        self._set_gripper(GRIPPER_OPEN_WIDTH)   # die placed — conveyor monitor takes over
+        self._move(BILL_PRE_SET_ON_CONVEYOR)
+        self._move(BILL_HOME)
+
+        # Block until conveyor monitor completes one cycle and exits
+        self.get_logger().info('Waiting for conveyor to complete...')
+        self._monitor_thread.join()
+
+        self.get_logger().info('=== Routine complete ===')
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = BillRoutineTest()
+
+    executor = MultiThreadedExecutor(num_threads=4)
+    executor.add_node(node)
+    spin_thread = threading.Thread(target=executor.spin, daemon=True)
+    spin_thread.start()
+
+    try:
+        node.run()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        executor.shutdown()
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/bill_cam_test.py
+++ b/tests/bill_cam_test.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""
+bill_cam_test.py  —  BILL camera presentation + pip search test
+
+Ask user for target pip (1-6), then loop:
+  - Normal pickup → present → set down, up to 4 attempts
+  - If not found after 4, do one twist pickup → present → set down
+  - Continue normal pickup → present → set down until found
+When target pip found: place die on conveyor instead of setting down, go home.
+
+Run:
+    python3 tests/bill_cam_test.py
+"""
+
+import sys
+import time
+import threading
+
+import cv2
+import numpy as np
+import matplotlib
+matplotlib.use('TkAgg')
+import matplotlib.pyplot as plt
+
+import rclpy
+from rclpy.node import Node
+from rclpy.action import ActionClient
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
+
+from fanuc_interfaces.action import JointPose, OnRobotGripper
+
+sys.path.insert(0, 'src/dice_game/dice_game')
+import mvsdk
+
+# ── Joint positions ───────────────────────────────────────────────────────────
+CAM_PICKUP           = [-51.39, 45.68, -24.74,  -0.256, -65.65, -80.36]
+CAM_PICKUP_UP        = [-51.39, 42.42, -15.89,  -0.242, -74.5,  -80.36]
+CAM_PICKUP_TWIST     = [-49.68, 44.85, -25.84,  -0.41,  -64.43,   4.71]
+CAM_PICKUP_TWIST_UP  = [-49.68, 41.86, -18.16,   0.386, -72.1,    4.77]
+CAM_PRESENT          = [-78.68, 24.16, -42.14,  162.96, -43.58, -207.59]
+SETDOWN              = [-49.74, 54.33, -92.74,  139.64, -92.23, -223.70]
+SETDOWN_UP           = [-49.64, 38.44, -78.20,  138.99, -81.18, -214.21]
+PRE_SET_ON_CONVEYOR  = [-89.51,   18.89,  -12.84,   1.14,  -75.99, -48.22]
+SET_ON_CONVEYOR      = [-89.51,   22.82,  -27.22,   1.25,  -61.61, -48.54]
+PRE_PICK_DJ_CONVEYOR = [-112.73,  25.87,   -7.33,   0.01, -82.68, -22.83]
+PICK_DJ_CONVEYOR     = [-112.73, 29.14,  -22.28,   -0.01, -67.72, -22.83]
+intermediate_bill_conveyor =[-86.88, 27.74, 6.81, 0.36, -97.26, -44.93]
+HOME                 = [0.0,      0.0,     0.0,     0.0,   -90.0,  -45.0]
+
+# ── Gripper ───────────────────────────────────────────────────────────────────
+GRIPPER_OPEN_WIDTH  = 100  # mm
+GRIPPER_CLOSE_WIDTH = 35   # mm
+GRIPPER_FORCE       = 40   # N
+
+MOTION_COMPLETE_TIMEOUT = 60.0
+
+
+class BillCamTest(Node):
+    def __init__(self):
+        super().__init__('bill_cam_test')
+        cb = ReentrantCallbackGroup()
+        self._joints  = ActionClient(self, JointPose,      'BILL/joint_pose',      callback_group=cb)
+        self._gripper = ActionClient(self, OnRobotGripper, 'BILL/onrobot_gripper', callback_group=cb)
+        self._annotated = None
+
+    # ── ROS2 helpers ──────────────────────────────────────────────────────────
+    def _wait(self, future, timeout=30.0):
+        deadline = time.time() + timeout
+        while not future.done():
+            if time.time() > deadline:
+                raise TimeoutError('Future timed out')
+            time.sleep(0.02)
+        return future.result()
+
+    def _move(self, joints: list, speed: int = 0):
+        self.get_logger().info(f'Move → {joints}' + (f' @ {speed}mm/s' if speed else ''))
+        goal = JointPose.Goal()
+        goal.joint1, goal.joint2, goal.joint3 = joints[0], joints[1], joints[2]
+        goal.joint4, goal.joint5, goal.joint6 = joints[3], joints[4], joints[5]
+        goal.speed = speed
+        self._joints.wait_for_server()
+        gh = self._wait(self._joints.send_goal_async(goal))
+        if not gh.accepted:
+            raise RuntimeError('Joint move rejected')
+        self._wait(gh.get_result_async(), timeout=MOTION_COMPLETE_TIMEOUT)
+
+    def _set_gripper(self, width: int):
+        goal = OnRobotGripper.Goal()
+        goal.width = width
+        goal.force = GRIPPER_FORCE
+        self._gripper.wait_for_server()
+        gh = self._wait(self._gripper.send_goal_async(goal))
+        if not gh.accepted:
+            raise RuntimeError('Gripper goal rejected')
+        self._wait(gh.get_result_async())
+        state = 'OPEN' if width >= GRIPPER_OPEN_WIDTH else 'CLOSE'
+        self.get_logger().info(f'Gripper {state}')
+        time.sleep(2.0)
+
+    # ── Camera ────────────────────────────────────────────────────────────────
+    def _capture_image(self) -> np.ndarray:
+        devs = mvsdk.CameraEnumerateDevice()
+        if len(devs) < 1:
+            raise RuntimeError('No MindVision camera found. Check ethernet cable.')
+
+        hCamera = None
+        for attempt in range(5):
+            try:
+                hCamera = mvsdk.CameraInit(devs[0], -1, -1)
+                break
+            except Exception as e:
+                self.get_logger().warn(f'CameraInit attempt {attempt+1} failed: {e}')
+                time.sleep(2.0)
+        if hCamera is None:
+            raise RuntimeError('CameraInit failed after 5 attempts')
+
+        cap = mvsdk.CameraGetCapability(hCamera)
+        mono = (cap.sIspCapacity.bMonoSensor != 0)
+        fmt = mvsdk.CAMERA_MEDIA_TYPE_MONO8 if mono else mvsdk.CAMERA_MEDIA_TYPE_BGR8
+        mvsdk.CameraSetIspOutFormat(hCamera, fmt)
+        mvsdk.CameraSetTriggerMode(hCamera, 0)
+        mvsdk.CameraSetAeState(hCamera, 0)
+        mvsdk.CameraSetExposureTime(hCamera, 30 * 1000)
+        mvsdk.CameraPlay(hCamera)
+
+        channels = 1 if mono else 3
+        buf_size = cap.sResolutionRange.iWidthMax * cap.sResolutionRange.iHeightMax * channels
+        pFrameBuffer = mvsdk.CameraAlignMalloc(buf_size, 16)
+        try:
+            pRawData, FrameHead = mvsdk.CameraGetImageBuffer(hCamera, 2000)
+            mvsdk.CameraImageProcess(hCamera, pRawData, pFrameBuffer, FrameHead)
+            mvsdk.CameraReleaseImageBuffer(hCamera, pRawData)
+            frame_data = (mvsdk.c_ubyte * FrameHead.uBytes).from_address(pFrameBuffer)
+            frame = np.frombuffer(frame_data, dtype=np.uint8).reshape(
+                (FrameHead.iHeight, FrameHead.iWidth, channels))
+            return frame.copy()
+        finally:
+            mvsdk.CameraUnInit(hCamera)
+            mvsdk.CameraAlignFree(pFrameBuffer)
+
+    def _count_pips(self, image: np.ndarray) -> int:
+        hsv = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
+        mask = cv2.inRange(hsv, np.array([15, 60, 40]), np.array([45, 255, 255]))
+        kernel = np.ones((5, 5), np.uint8)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel, iterations=2)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN,  kernel, iterations=1)
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        if not contours:
+            self.get_logger().warn('No yellow die detected in image')
+            self._annotated = image.copy()
+            return -1
+
+        x, y, w, h = cv2.boundingRect(max(contours, key=cv2.contourArea))
+        margin = 8
+        x = max(0, x - margin);  y = max(0, y - margin)
+        w = min(image.shape[1] - x, w + 2 * margin)
+        h = min(image.shape[0] - y, h + 2 * margin)
+
+        roi = image[y:y+h, x:x+w].copy()
+        roi_bright = cv2.convertScaleAbs(roi, alpha=3.5, beta=50)
+        gray = cv2.cvtColor(roi_bright, cv2.COLOR_BGR2GRAY)
+        blur = cv2.GaussianBlur(gray, (3, 3), 0)
+
+        _, dark_otsu = cv2.threshold(blur, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+        dark_adapt = cv2.adaptiveThreshold(
+            blur, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, cv2.THRESH_BINARY_INV, 21, 8)
+        dark = cv2.bitwise_or(dark_otsu, dark_adapt)
+        dark = cv2.morphologyEx(dark, cv2.MORPH_OPEN, np.ones((2, 2), np.uint8))
+
+        pip_contours, _ = cv2.findContours(dark, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        border_x = int(w * 0.12);  border_y = int(h * 0.12)
+        pip_count = 0
+        annotated = image.copy()
+        cv2.rectangle(annotated, (x, y), (x+w, y+h), (255, 0, 0), 2)
+
+        for c in pip_contours:
+            area = cv2.contourArea(c)
+            if area < 20 or area > 6000:
+                continue
+            perimeter = cv2.arcLength(c, True)
+            if perimeter == 0 or (4 * np.pi * area / (perimeter ** 2)) <= 0.55:
+                continue
+            M = cv2.moments(c)
+            if M['m00'] == 0:
+                continue
+            cx = int(M['m10'] / M['m00']) + x
+            cy = int(M['m01'] / M['m00']) + y
+            if (cx - x) < border_x or (cx - x) > w - border_x:
+                continue
+            if (cy - y) < border_y or (cy - y) > h - border_y:
+                continue
+            pip_count += 1
+            cv2.drawContours(annotated, [c + np.array([[[x, y]]])], -1, (0, 255, 0), 2)
+            cv2.circle(annotated, (cx, cy), 4, (0, 0, 255), -1)
+
+        cv2.putText(annotated, f'pips: {pip_count}', (10, 40),
+                    cv2.FONT_HERSHEY_SIMPLEX, 1.2, (0, 255, 0), 2)
+        self._annotated = annotated
+        return pip_count
+
+    def _capture_and_show(self, label: str, target: int = 0) -> int:
+        """Capture, count, show annotated pop-up for 2 seconds, return pip count."""
+        self.get_logger().info(f'Capturing ({label})...')
+        frame = self._capture_image()
+        count = self._count_pips(frame)
+        self.get_logger().info(f'Pip count: {count}')
+        cv2.imwrite('dice_capture.jpg', frame)
+        cv2.imwrite('dice_annotated.jpg', self._annotated)
+        rgb = cv2.cvtColor(self._annotated, cv2.COLOR_BGR2RGB)
+        fig, ax = plt.subplots()
+        ax.imshow(rgb)
+        ax.set_title(f'Pips: {count}  (target: {target})')
+        ax.axis('off')
+        plt.tight_layout()
+        plt.show(block=False)
+        plt.pause(2.0)
+        plt.close(fig)
+        return count
+
+    # ── Movement sub-routines ─────────────────────────────────────────────────
+    def _pickup_from_dj_conveyor_present(self, label: str, target: int) -> int:
+        """Pick die off DJ's conveyor, move to cam_present, capture. Still holding die."""
+        self._move(HOME, speed=300)
+        self._set_gripper(GRIPPER_OPEN_WIDTH)
+        self._move(PRE_PICK_DJ_CONVEYOR)
+        self._move(PICK_DJ_CONVEYOR)
+        self._set_gripper(GRIPPER_CLOSE_WIDTH)
+        self._move(PRE_PICK_DJ_CONVEYOR)
+        self._move(intermediate_bill_conveyor)
+        self._move(CAM_PRESENT, speed=50)
+        return self._capture_and_show(label, target)
+
+    def _normal_pickup_present(self, label: str, target: int) -> int:
+        """Pick up normally, move to cam_present, capture. Returns pip count. Still holding die."""
+        self._move(CAM_PICKUP_UP, speed=300)
+        self._move(CAM_PICKUP)
+        self._set_gripper(GRIPPER_CLOSE_WIDTH)
+        self._move(CAM_PICKUP_UP)
+        self._move(CAM_PRESENT, speed=50)
+        return self._capture_and_show(label, target)
+
+    def _set_down(self):
+        """Set die back down on table from cam_present position."""
+        self._move(SETDOWN_UP)
+        self._move(SETDOWN)
+        self._set_gripper(GRIPPER_OPEN_WIDTH)
+        self._move(SETDOWN_UP)
+
+    def _twist_pickup_present(self, label: str, target: int) -> int:
+        """Pick up with twist grip, move to cam_present, capture. Returns pip count. Still holding die."""
+        self._move(CAM_PICKUP_TWIST_UP, speed = 300)
+        self._move(CAM_PICKUP_TWIST)
+        self._set_gripper(GRIPPER_CLOSE_WIDTH)
+        self._move(CAM_PICKUP_TWIST_UP)
+        self._move(CAM_PICKUP_UP)
+        self._move(CAM_PRESENT, speed=50)
+        return self._capture_and_show(label, target)
+
+    def _place_on_conveyor(self):
+        """Set die down normally, re-pick vertically, then place on conveyor."""
+        # Set down as normal
+        self._set_down()
+        # Pick up vertically
+        self._move(CAM_PICKUP_TWIST_UP, speed=300)
+        self._move(CAM_PICKUP_TWIST)
+        self._set_gripper(GRIPPER_CLOSE_WIDTH)
+        self._move(CAM_PICKUP_TWIST_UP)
+        # Place on conveyor
+        self._move(intermediate_bill_conveyor)
+        self._move(PRE_SET_ON_CONVEYOR)
+        self._move(SET_ON_CONVEYOR)
+        self._set_gripper(GRIPPER_OPEN_WIDTH)
+        self._move(PRE_SET_ON_CONVEYOR)
+
+    # ── Main sequence ─────────────────────────────────────────────────────────
+    def run(self):
+        # Get target pip from user
+        while True:
+            try:
+                target = int(input('Enter target pip count (1-6): '))
+                if 1 <= target <= 6:
+                    break
+                print('Please enter a number between 1 and 6.')
+            except ValueError:
+                print('Invalid input. Please enter a number.')
+
+        self.get_logger().info(f'=== Searching for pip {target} ===')
+
+        self._set_gripper(GRIPPER_OPEN_WIDTH)
+
+        attempt = 0
+        twist_done = False
+        capture_num = 0
+
+        # First pick is from DJ's conveyor
+        capture_num += 1
+        count = self._pickup_from_dj_conveyor_present(f'dj_conveyor_{capture_num}', target)
+        if count == target:
+            self.get_logger().info(f'Target pip {target} found on first pick! Placing on conveyor.')
+            self._place_on_conveyor()
+            self._move(HOME)
+            self.get_logger().info('=== Done — die placed on conveyor, robot at home ===')
+            return
+        self._set_down()
+        attempt += 1
+
+        while True:
+            # After 3 failed normal attempts, do one twist if not already done
+            if attempt == 4 and not twist_done:
+                self.get_logger().info('3 normal attempts failed — trying twist grip')
+                capture_num += 1
+                count = self._twist_pickup_present(f'twist_{capture_num}', target)
+                if count == target:
+                    self.get_logger().info(f'Target pip {target} found on twist! Placing on conveyor.')
+                    self._place_on_conveyor()
+                    break
+                self._set_down()
+                twist_done = True
+
+            # Normal pickup
+            capture_num += 1
+            count = self._normal_pickup_present(f'normal_{capture_num}', target)
+            if count == target:
+                self.get_logger().info(f'Target pip {target} found! Placing on conveyor.')
+                self._place_on_conveyor()
+                break
+            self._set_down()
+            attempt += 1
+
+        self._move(HOME)
+        self.get_logger().info('=== Done — die placed on conveyor, robot at home ===')
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = BillCamTest()
+
+    executor = MultiThreadedExecutor(num_threads=4)
+    executor.add_node(node)
+    spin_thread = threading.Thread(target=executor.spin, daemon=True)
+    spin_thread.start()
+
+    try:
+        node.run()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        executor.shutdown()
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/dj_cam_test.py
+++ b/tests/dj_cam_test.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""
+dj_cam_test.py  —  DJ camera presentation + pip search test
+
+Ask user for target pip (1-6), then loop:
+  - Normal pickup → present → set down, up to 3 attempts
+  - If not found after 3, do one twist pickup → present → set down
+  - Continue normal pickup → present → set down until found
+When target pip found: set down, re-pick vertically, place on conveyor, go home.
+
+Run:
+    python3 tests/dj_cam_test.py
+"""
+
+import sys
+import time
+import threading
+
+import cv2
+import numpy as np
+import matplotlib
+matplotlib.use('TkAgg')
+import matplotlib.pyplot as plt
+
+import rclpy
+from rclpy.node import Node
+from rclpy.action import ActionClient
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
+
+from fanuc_interfaces.action import JointPose, SchunkGripper
+
+sys.path.insert(0, 'src/dice_game/dice_game')
+import mvsdk
+
+# ── Joint positions ───────────────────────────────────────────────────────────
+CAM_PICKUP           = [71.35, 42.61, -25.51, -0.91, -66.07, 44.90]   # TODO
+CAM_PICKUP_UP        = [71.35, 39.17, -15.94, -0.86, -75.64, 44.75]   # TODO
+CAM_PICKUP_TWIST     = [69.43, 40.24, -27.88, -1.85, -61.39, -41.50]   # TODO
+CAM_PICKUP_TWIST_UP  = [69.43, 36.39, -17.89, -1.71, -71.37, -41.84]   # TODO
+CAM_PRESENT          = [65.87, 20.85, -27.87, -135.54, -37.71, 168.74]   # TODO
+SETDOWN              = [34.03, 53.90, -75.45, -122.12, -83.09, 194.72]   # TODO
+SETDOWN_UP           = [34.30, 42.04, -65.02, -120.87, -77.55, 185.76]   # TODO
+PRE_SET_ON_CONVEYOR  = [128.42, 36.69, -0.81, -1.22, -89.58, -9.54]   # TODO
+SET_ON_CONVEYOR      = [128.42, 38.38, -13.94, -1.26, -76.45, -9.25]   # TODO
+PRE_PICK_DJ_CONVEYOR      = [114.37, 22.08, -11.75, -1.73, -78.81, 0.68]   # TODO
+PICK_DJ_CONVEYOR          = [114.36, 25.1, -23.46, -1.84, -67.11, 1.06]   # TODO
+INTERMEDIATE_DJ_CONVEYOR  = [88.60, 26.60, -7.94, -0.69, -83.14, 30.37]   # TODO
+HOME                 = [0.0, 0.0, 0.0, 0.0, -90.0, 30.0]   # TODO
+
+# ── Gripper ───────────────────────────────────────────────────────────────────
+# Schunk gripper uses 'open' / 'close' commands (no width/force)
+
+MOTION_COMPLETE_TIMEOUT = 60.0
+
+
+class DjCamTest(Node):
+    def __init__(self):
+        super().__init__('dj_cam_test')
+        cb = ReentrantCallbackGroup()
+        self._joints  = ActionClient(self, JointPose,     'DJ/joint_pose',      callback_group=cb)
+        self._gripper = ActionClient(self, SchunkGripper, 'DJ/schunk_gripper',  callback_group=cb)
+        self._annotated = None
+
+    # ── ROS2 helpers ──────────────────────────────────────────────────────────
+    def _wait(self, future, timeout=30.0):
+        deadline = time.time() + timeout
+        while not future.done():
+            if time.time() > deadline:
+                raise TimeoutError('Future timed out')
+            time.sleep(0.02)
+        return future.result()
+
+    def _move(self, joints: list, speed: int = 0):
+        self.get_logger().info(f'Move → {joints}' + (f' @ {speed}mm/s' if speed else ''))
+        goal = JointPose.Goal()
+        goal.joint1, goal.joint2, goal.joint3 = joints[0], joints[1], joints[2]
+        goal.joint4, goal.joint5, goal.joint6 = joints[3], joints[4], joints[5]
+        goal.speed = speed
+        self._joints.wait_for_server()
+        gh = self._wait(self._joints.send_goal_async(goal))
+        if not gh.accepted:
+            raise RuntimeError('Joint move rejected')
+        self._wait(gh.get_result_async(), timeout=MOTION_COMPLETE_TIMEOUT)
+
+    def _set_gripper(self, command: str):
+        """command: 'open' or 'close'"""
+        goal = SchunkGripper.Goal()
+        goal.command = command
+        self._gripper.wait_for_server()
+        gh = self._wait(self._gripper.send_goal_async(goal))
+        if not gh.accepted:
+            raise RuntimeError('Gripper goal rejected')
+        self._wait(gh.get_result_async())
+        self.get_logger().info(f'Gripper {command.upper()}')
+        time.sleep(2.0)
+
+    # ── Camera ────────────────────────────────────────────────────────────────
+    def _capture_image(self) -> np.ndarray:
+        devs = mvsdk.CameraEnumerateDevice()
+        if len(devs) < 1:
+            raise RuntimeError('No MindVision camera found. Check ethernet cable.')
+
+        hCamera = None
+        for attempt in range(5):
+            try:
+                hCamera = mvsdk.CameraInit(devs[0], -1, -1)
+                break
+            except Exception as e:
+                self.get_logger().warn(f'CameraInit attempt {attempt+1} failed: {e}')
+                time.sleep(2.0)
+        if hCamera is None:
+            raise RuntimeError('CameraInit failed after 5 attempts')
+
+        cap = mvsdk.CameraGetCapability(hCamera)
+        mono = (cap.sIspCapacity.bMonoSensor != 0)
+        fmt = mvsdk.CAMERA_MEDIA_TYPE_MONO8 if mono else mvsdk.CAMERA_MEDIA_TYPE_BGR8
+        mvsdk.CameraSetIspOutFormat(hCamera, fmt)
+        mvsdk.CameraSetTriggerMode(hCamera, 0)
+        mvsdk.CameraSetAeState(hCamera, 0)
+        mvsdk.CameraSetExposureTime(hCamera, 30 * 1000)
+        mvsdk.CameraPlay(hCamera)
+
+        channels = 1 if mono else 3
+        buf_size = cap.sResolutionRange.iWidthMax * cap.sResolutionRange.iHeightMax * channels
+        pFrameBuffer = mvsdk.CameraAlignMalloc(buf_size, 16)
+        try:
+            pRawData, FrameHead = mvsdk.CameraGetImageBuffer(hCamera, 2000)
+            mvsdk.CameraImageProcess(hCamera, pRawData, pFrameBuffer, FrameHead)
+            mvsdk.CameraReleaseImageBuffer(hCamera, pRawData)
+            frame_data = (mvsdk.c_ubyte * FrameHead.uBytes).from_address(pFrameBuffer)
+            frame = np.frombuffer(frame_data, dtype=np.uint8).reshape(
+                (FrameHead.iHeight, FrameHead.iWidth, channels))
+            return frame.copy()
+        finally:
+            mvsdk.CameraUnInit(hCamera)
+            mvsdk.CameraAlignFree(pFrameBuffer)
+
+    def _count_pips(self, image: np.ndarray) -> int:
+        hsv = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
+        mask = cv2.inRange(hsv, np.array([15, 60, 40]), np.array([45, 255, 255]))
+        kernel = np.ones((5, 5), np.uint8)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel, iterations=2)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN,  kernel, iterations=1)
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        if not contours:
+            self.get_logger().warn('No yellow die detected in image')
+            self._annotated = image.copy()
+            return -1
+
+        x, y, w, h = cv2.boundingRect(max(contours, key=cv2.contourArea))
+        margin = 8
+        x = max(0, x - margin);  y = max(0, y - margin)
+        w = min(image.shape[1] - x, w + 2 * margin)
+        h = min(image.shape[0] - y, h + 2 * margin)
+
+        roi = image[y:y+h, x:x+w].copy()
+        roi_bright = cv2.convertScaleAbs(roi, alpha=3.5, beta=50)
+        gray = cv2.cvtColor(roi_bright, cv2.COLOR_BGR2GRAY)
+        blur = cv2.GaussianBlur(gray, (3, 3), 0)
+
+        _, dark_otsu = cv2.threshold(blur, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+        dark_adapt = cv2.adaptiveThreshold(
+            blur, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, cv2.THRESH_BINARY_INV, 21, 8)
+        dark = cv2.bitwise_or(dark_otsu, dark_adapt)
+        dark = cv2.morphologyEx(dark, cv2.MORPH_OPEN, np.ones((2, 2), np.uint8))
+
+        pip_contours, _ = cv2.findContours(dark, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        border_x = int(w * 0.12);  border_y = int(h * 0.12)
+        pip_count = 0
+        annotated = image.copy()
+        cv2.rectangle(annotated, (x, y), (x+w, y+h), (255, 0, 0), 2)
+
+        for c in pip_contours:
+            area = cv2.contourArea(c)
+            if area < 20 or area > 6000:
+                continue
+            perimeter = cv2.arcLength(c, True)
+            if perimeter == 0 or (4 * np.pi * area / (perimeter ** 2)) <= 0.55:
+                continue
+            M = cv2.moments(c)
+            if M['m00'] == 0:
+                continue
+            cx = int(M['m10'] / M['m00']) + x
+            cy = int(M['m01'] / M['m00']) + y
+            if (cx - x) < border_x or (cx - x) > w - border_x:
+                continue
+            if (cy - y) < border_y or (cy - y) > h - border_y:
+                continue
+            pip_count += 1
+            cv2.drawContours(annotated, [c + np.array([[[x, y]]])], -1, (0, 255, 0), 2)
+            cv2.circle(annotated, (cx, cy), 4, (0, 0, 255), -1)
+
+        cv2.putText(annotated, f'pips: {pip_count}', (10, 40),
+                    cv2.FONT_HERSHEY_SIMPLEX, 1.2, (0, 255, 0), 2)
+        self._annotated = annotated
+        return pip_count
+
+    def _capture_and_show(self, label: str, target: int = 0) -> int:
+        """Capture, count, show annotated pop-up for 2 seconds, return pip count."""
+        self.get_logger().info(f'Capturing ({label})...')
+        frame = self._capture_image()
+        count = self._count_pips(frame)
+        self.get_logger().info(f'Pip count: {count}')
+        cv2.imwrite('dice_capture.jpg', frame)
+        cv2.imwrite('dice_annotated.jpg', self._annotated)
+        rgb = cv2.cvtColor(self._annotated, cv2.COLOR_BGR2RGB)
+        fig, ax = plt.subplots()
+        ax.imshow(rgb)
+        ax.set_title(f'Pips: {count}  (target: {target})')
+        ax.axis('off')
+        plt.tight_layout()
+        plt.show(block=False)
+        plt.pause(2.0)
+        plt.close(fig)
+        return count
+
+    # ── Movement sub-routines ─────────────────────────────────────────────────
+    def _pickup_from_bill_conveyor_present(self, label: str, target: int) -> int:
+        """Pick die off DJ's conveyor, move to cam_present, capture. Still holding die."""
+        self._move(HOME, speed=300)
+        self._set_gripper('open')
+        self._move(PRE_PICK_DJ_CONVEYOR)
+        self._move(PICK_DJ_CONVEYOR)
+        self._set_gripper('close')
+        self._move(PRE_PICK_DJ_CONVEYOR)
+        self._move(INTERMEDIATE_DJ_CONVEYOR)
+        self._move(CAM_PICKUP_UP)
+        self._move(CAM_PRESENT, speed=50)
+        return self._capture_and_show(label, target)
+
+    def _normal_pickup_present(self, label: str, target: int) -> int:
+        """Pick up normally, move to cam_present, capture. Returns pip count. Still holding die."""
+        self._move(CAM_PICKUP_UP, speed=300)
+        self._move(CAM_PICKUP)
+        self._set_gripper('close')
+        self._move(CAM_PICKUP_UP)
+        self._move(CAM_PRESENT, speed=50)
+        return self._capture_and_show(label, target)
+
+    def _set_down(self):
+        """Set die back down on table from cam_present position."""
+        self._move(SETDOWN_UP, speed = 300)
+        self._move(SETDOWN)
+        self._set_gripper('open')
+        self._move(SETDOWN_UP)
+
+    def _twist_pickup_present(self, label: str, target: int) -> int:
+        """Pick up with twist grip, move to cam_present, capture. Returns pip count. Still holding die."""
+        self._move(CAM_PICKUP_TWIST_UP, speed=300)
+        self._move(CAM_PICKUP_TWIST)
+        self._set_gripper('close')
+        self._move(CAM_PICKUP_TWIST_UP)
+        self._move(CAM_PICKUP_UP)
+        self._move(CAM_PRESENT, speed=50)
+        return self._capture_and_show(label, target)
+
+    def _place_on_conveyor(self):
+        """Set die down normally, re-pick vertically, then place on conveyor."""
+        self._set_down()
+        self._move(CAM_PICKUP_TWIST_UP, speed=300)
+        self._move(CAM_PICKUP_TWIST)
+        self._set_gripper('close')
+        self._move(CAM_PICKUP_TWIST_UP)
+        self._move(INTERMEDIATE_DJ_CONVEYOR)
+        self._move(PRE_SET_ON_CONVEYOR)
+        self._move(SET_ON_CONVEYOR)
+        self._set_gripper('open')
+        self._move(PRE_SET_ON_CONVEYOR)
+
+    # ── Main sequence ─────────────────────────────────────────────────────────
+    def run(self):
+        while True:
+            try:
+                target = int(input('Enter target pip count (1-6): '))
+                if 1 <= target <= 6:
+                    break
+                print('Please enter a number between 1 and 6.')
+            except ValueError:
+                print('Invalid input. Please enter a number.')
+
+        self.get_logger().info(f'=== Searching for pip {target} ===')
+
+        self._set_gripper('open')
+
+        attempt = 0
+        twist_done = False
+        capture_num = 0
+
+        # First pick is from DJ's conveyor
+        capture_num += 1
+        count = self._pickup_from_bill_conveyor_present(f'bill_conveyor_{capture_num}', target)
+        if count == target:
+            self.get_logger().info(f'Target pip {target} found on first pick! Placing on conveyor.')
+            self._place_on_conveyor()
+            self._move(HOME)
+            self.get_logger().info('=== Done — die placed on conveyor, robot at home ===')
+            return
+        self._set_down()
+        attempt += 1
+
+        while True:
+            # After 3 failed normal attempts, do one twist if not already done
+            if attempt == 4 and not twist_done:
+                self.get_logger().info('3 normal attempts failed — trying twist grip')
+                capture_num += 1
+                count = self._twist_pickup_present(f'twist_{capture_num}', target)
+                if count == target:
+                    self.get_logger().info(f'Target pip {target} found on twist! Placing on conveyor.')
+                    self._place_on_conveyor()
+                    break
+                self._set_down()
+                twist_done = True
+
+            # Normal pickup
+            capture_num += 1
+            count = self._normal_pickup_present(f'normal_{capture_num}', target)
+            if count == target:
+                self.get_logger().info(f'Target pip {target} found! Placing on conveyor.')
+                self._place_on_conveyor()
+                break
+            self._set_down()
+            attempt += 1
+
+        self._move(HOME)
+        self.get_logger().info('=== Done — die placed on conveyor, robot at home ===')
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = DjCamTest()
+
+    executor = MultiThreadedExecutor(num_threads=4)
+    executor.add_node(node)
+    spin_thread = threading.Thread(target=executor.spin, daemon=True)
+    spin_thread.start()
+
+    try:
+        node.run()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        executor.shutdown()
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/jog_test.py
+++ b/tests/jog_test.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""
+jog_test.py
+
+Interactive test for both robots. Run from the workspace root after sourcing:
+    python3 tests/jog_test.py
+
+Requires driver nodes to be running:
+    ros2 launch launch/start.launch.py robot_name:=DJ   robot_ip:=10.8.4.16
+    ros2 launch launch/start.launch.py robot_name:=BILL robot_ip:=10.8.4.6
+"""
+
+import sys
+import time
+import threading
+
+import rclpy
+from rclpy.node import Node
+from rclpy.action import ActionClient
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
+
+from fanuc_interfaces.action import JointPose, SchunkGripper, OnRobotGripper, Conveyor
+from fanuc_interfaces.msg import ProxReadings
+
+
+class RobotTester(Node):
+    def __init__(self):
+        super().__init__('jog_test')
+        cb = ReentrantCallbackGroup()
+
+        # DJ clients
+        self.dj_joints  = ActionClient(self, JointPose,    'DJ/joint_pose',       callback_group=cb)
+        self.dj_schunk  = ActionClient(self, SchunkGripper,'DJ/schunk_gripper',   callback_group=cb)
+        self.dj_convey  = ActionClient(self, Conveyor,     'DJ/conveyor',         callback_group=cb)
+
+        # BILL clients
+        self.bill_joints   = ActionClient(self, JointPose,      'BILL/joint_pose',      callback_group=cb)
+        self.bill_onrobot  = ActionClient(self, OnRobotGripper, 'BILL/onrobot_gripper', callback_group=cb)
+        self.bill_convey   = ActionClient(self, Conveyor,       'BILL/conveyor',        callback_group=cb)
+
+        # Prox sensor cache
+        self._prox = {'DJ': {'left': 0, 'right': 0}, 'BILL': {'left': 0, 'right': 0}}
+        self.create_subscription(ProxReadings, 'DJ/prox_readings',
+            lambda msg: self._prox['DJ'].update({'left': int(msg.left), 'right': int(msg.right)}), 10)
+        self.create_subscription(ProxReadings, 'BILL/prox_readings',
+            lambda msg: self._prox['BILL'].update({'left': int(msg.left), 'right': int(msg.right)}), 10)
+
+    # ------------------------------------------------------------------
+    def _wait(self, future, timeout=10.0):
+        deadline = time.time() + timeout
+        while not future.done():
+            if time.time() > deadline:
+                raise TimeoutError('Action timed out')
+            time.sleep(0.02)
+        return future.result()
+
+    def _send_joint(self, client, j1, j2, j3, j4, j5, j6):
+        goal = JointPose.Goal()
+        goal.joint1, goal.joint2, goal.joint3 = j1, j2, j3
+        goal.joint4, goal.joint5, goal.joint6 = j4, j5, j6
+        client.wait_for_server(timeout_sec=5.0)
+        gh = self._wait(client.send_goal_async(goal))
+        if not gh.accepted:
+            print('  Goal rejected.')
+            return False
+        result = self._wait(gh.get_result_async(), timeout=30.0)
+        print(f'  Done. success={result.result.success}')
+        return result.result.success
+
+    def _send_conveyor(self, client, cmd):
+        goal = Conveyor.Goal()
+        goal.command = cmd
+        client.wait_for_server(timeout_sec=5.0)
+        gh = self._wait(client.send_goal_async(goal))
+        if not gh.accepted:
+            print('  Goal rejected.')
+            return
+        self._wait(gh.get_result_async())
+        print(f'  Conveyor {cmd}.')
+
+    def _send_schunk(self, cmd):
+        goal = SchunkGripper.Goal()
+        goal.command = cmd
+        self.dj_schunk.wait_for_server(timeout_sec=5.0)
+        gh = self._wait(self.dj_schunk.send_goal_async(goal))
+        if not gh.accepted:
+            print('  Goal rejected.')
+            return
+        self._wait(gh.get_result_async())
+        print(f'  Schunk {cmd}.')
+
+    def _run_conveyor_sensors(self, robot: str, client, start_sensor: str, stop_sensor: str,
+                              direction: str = 'forward', timeout: float = 20.0):
+        """Wait for start_sensor to trip, run conveyor, stop when stop_sensor trips.
+        Each sensor gets its own timeout window."""
+        prox = self._prox[robot]
+
+        print(f'  [{robot}] Waiting for start sensor ({start_sensor}) to trip — block it now...')
+        deadline = time.time() + timeout
+        while not prox[start_sensor]:
+            if time.time() > deadline:
+                print('  Timed out waiting for start sensor.')
+                return
+            time.sleep(0.05)
+        print(f'  [{robot}] Start sensor tripped — conveyor ON ({direction}).')
+        self._send_conveyor(client, direction)
+
+        print(f'  [{robot}] Waiting for stop sensor ({stop_sensor}) to trip...')
+        deadline = time.time() + timeout
+        while not prox[stop_sensor]:
+            if time.time() > deadline:
+                print('  Timed out waiting for stop sensor.')
+                self._send_conveyor(client, 'stop')
+                return
+            time.sleep(0.05)
+        self._send_conveyor(client, 'stop')
+        print(f'  [{robot}] Stop sensor tripped — conveyor OFF.')
+
+    def _send_onrobot(self, width, force):
+        goal = OnRobotGripper.Goal()
+        goal.width = width
+        goal.force = force
+        self.bill_onrobot.wait_for_server(timeout_sec=5.0)
+        gh = self._wait(self.bill_onrobot.send_goal_async(goal))
+        if not gh.accepted:
+            print('  Goal rejected.')
+            return
+        self._wait(gh.get_result_async())
+        print(f'  OnRobot width={width}mm force={force}N.')
+
+    # ------------------------------------------------------------------
+    def run_menu(self):
+        menu = """
+========================================
+  Robot Jog Test
+========================================
+  DJ joints     : dj j1 j2 j3 j4 j5 j6
+  BILL joints   : bill j1 j2 j3 j4 j5 j6
+
+  DJ conveyor   : djc              (sensor: start=left  stop=right, forward)
+                  djc [forward|reverse|stop]   (manual override)
+  BILL conveyor : bc               (sensor: start=right stop=left,  reverse)
+                  bc  [forward|reverse|stop]   (manual override)
+
+  DJ schunk     : schunk [open|close]
+  BILL onrobot  : onrobot [open|close]
+                  onrobot width force
+
+  quit          : q
+========================================
+"""
+        print(menu)
+        while True:
+            try:
+                raw = input('> ').strip()
+            except (EOFError, KeyboardInterrupt):
+                break
+
+            if not raw:
+                continue
+
+            parts = raw.split()
+            cmd = parts[0].lower()
+
+            try:
+                if cmd == 'q':
+                    break
+
+                elif cmd == 'dj':
+                    if len(parts) != 7:
+                        print('Usage: dj j1 j2 j3 j4 j5 j6')
+                        continue
+                    joints = [float(x) for x in parts[1:]]
+                    print(f'  Moving DJ to {joints}')
+                    self._send_joint(self.dj_joints, *joints)
+
+                elif cmd == 'bill':
+                    if len(parts) != 7:
+                        print('Usage: bill j1 j2 j3 j4 j5 j6')
+                        continue
+                    joints = [float(x) for x in parts[1:]]
+                    print(f'  Moving BILL to {joints}')
+                    self._send_joint(self.bill_joints, *joints)
+
+                elif cmd == 'djc':
+                    if len(parts) == 1:
+                        print('DJ sensor-controlled conveyor (start=left, stop=right, forward)')
+                        self._run_conveyor_sensors('DJ', self.dj_convey, 'left', 'right')
+                    elif len(parts) == 2 and parts[1] in ('forward', 'reverse', 'stop'):
+                        self._send_conveyor(self.dj_convey, parts[1])
+                    else:
+                        print('Usage: djc              (sensor-controlled)')
+                        print('       djc [forward|reverse|stop]   (manual)')
+
+                elif cmd == 'bc':
+                    if len(parts) == 1:
+                        print('BILL sensor-controlled conveyor (start=right, stop=left, reverse)')
+                        self._run_conveyor_sensors('BILL', self.bill_convey, 'right', 'left', direction='reverse')
+                    elif len(parts) == 2 and parts[1] in ('forward', 'reverse', 'stop'):
+                        self._send_conveyor(self.bill_convey, parts[1])
+                    else:
+                        print('Usage: bc              (sensor-controlled)')
+                        print('       bc  [forward|reverse|stop]   (manual)')
+
+                elif cmd == 'djcs':
+                    print('DJ sensor-controlled conveyor test (start=left, stop=right)')
+                    self._run_conveyor_sensors('DJ', self.dj_convey, 'left', 'right')
+
+                elif cmd == 'bcs':
+                    print('BILL sensor-controlled conveyor test (start=right, stop=left)')
+                    self._run_conveyor_sensors('BILL', self.bill_convey, 'right', 'left', direction='reverse')
+
+                elif cmd == 'schunk':
+                    if len(parts) != 2 or parts[1] not in ('open', 'close'):
+                        print('Usage: schunk [open|close]')
+                        continue
+                    self._send_schunk(parts[1])
+
+                elif cmd == 'onrobot':
+                    if len(parts) == 2:
+                        width = 80 if parts[1] == 'open' else 35
+                        force = 40
+                    elif len(parts) == 3:
+                        width, force = int(parts[1]), int(parts[2])
+                    else:
+                        print('Usage: onrobot [open|close]  OR  onrobot width force')
+                        continue
+                    self._send_onrobot(width, force)
+
+                else:
+                    print(f'Unknown command: {cmd}')
+
+            except TimeoutError as e:
+                print(f'  Timeout: {e}')
+            except Exception as e:
+                print(f'  Error: {e}')
+
+
+def main():
+    rclpy.init()
+    node = RobotTester()
+
+    executor = MultiThreadedExecutor(num_threads=4)
+    executor.add_node(node)
+    spin_thread = threading.Thread(target=executor.spin, daemon=True)
+    spin_thread.start()
+
+    node.run_menu()
+
+    executor.shutdown()
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Adds a `dice_game` ROS2 package implementing a sequential pip-counting game using two FANUC robots, two conveyors, and a MindVision ethernet camera.

- **DJ** (Schunk gripper) finds and sends odd pips (1, 3, 5) to BILL via back conveyor
- **BILL** (OnRobot gripper) finds and sends even pips (2, 4, 6) back to DJ via front conveyor
- DJ sets pip 6 die back down at the start position to end the game
- Camera accessed directly via `mvsdk` SDK — no separate camera server node needed
- Pip detection: yellow HSV mask → ROI → dual-threshold (Otsu + adaptive) → circularity filter
- Grip loop: 3 normal attempts → 1 twist grip → continue until correct face found

## Driver Changes

- `JointPose.action`: added `int32 speed` field for per-move speed control
- `joint_pose_server`: expanded joint limits to ±270°, position verification loop, 0.3s pre-poll delay, speed reset on startup
- `robot_controller` (both copies): `time.sleep(0.1)` between `is_moving()` reads fixes race condition
- `onrobot_server`, `schunk_server`: 2s asyncio settle delay before `succeed()`

## New Interfaces

- `DiceState.msg`, `RequestHandoff.srv`, `CapturePip.srv`

## Test Scripts

- `jog_test.py`, `basic_routine_test.py`, `bill_cam_test.py`, `dj_cam_test.py`

GitHub username: katebouse-hub